### PR TITLE
Characteristics fixed

### DIFF
--- a/Euler_equations_TammannEOS.ipynb
+++ b/Euler_equations_TammannEOS.ipynb
@@ -2,7 +2,10 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "# Nearly-incompressible flow: the Tammann equation of state\n",
     "\n",
@@ -35,7 +38,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## Exact solution\n",
     "\n",
@@ -82,7 +88,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "### Rankine-Hugoniot conditions for shock waves\n",
     "Let us first consider the case in which both the 1-wave and the 3-wave are shocks. The velocity of each\n",
@@ -204,7 +213,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "### Riemann invariants for rarefaction waves\n",
     "\n",
@@ -280,7 +292,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "### Solution in the pressure-velocity plane\n",
     "\n",
@@ -291,7 +306,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false,
+    "deletable": true,
+    "editable": true,
     "tags": [
      "hide"
     ]
@@ -308,7 +324,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "<font color='red'>Note the cell below doesn't render in the pdf</font>"
    ]
@@ -316,7 +335,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
     "# Initial states [density, velocity, pressure]\n",
@@ -331,7 +353,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "### Full solution\n",
     "In order to get the full solution, we need some additional quantities. Equations (\\ref{RH-phis}) will yield the contact discontinuity speed $s_2=u_*$ in terms of $p_*$. We can also calculate $F_l$ and $F_r$ from (\\ref{Qk-f}), and we can substitute in (\\ref{RH-speeds}) to obtain the corresponding wave speeds. With this, we can provide the full solution of the Riemann problem. In the next section, we will show the full solution for different examples.  Here we define a function to plot the exact solution of the Riemann problem and parameters that we will use for the different examples."
@@ -341,7 +366,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -369,14 +395,20 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## Examples of Riemann Solutions"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "### Problem 1: Sod shock tube in water\n",
     "We first consider the classic Sod shock tube problem with higher density and pressure on the left state than on the right state and both sides initially at rest. The main difference with the classic problem is that in this case the shock tube is filled with water and not with air. The propagation of waves in water can be accurately modeled using $\\gamma = 7.15$, $p_{\\infty} = 3\\times 10^8$ and $\\rho\\approx 1000 kg/m^3$; see <cite data-cite=\"del2016computational\"><a href=\"riemann.html#del2016computational\">(del Razo 2016)</a></cite>. A value of $p_{atm}=101325 Pa$ is used for Atmospheric pressure."
@@ -386,7 +418,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -399,7 +432,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "We take a very large jump in pressure so that it's clear the left-going wave is a rarefaction. With a more modest jump the rarefaction wave barely spreads and appears more like a discontinuity."
    ]
@@ -407,7 +443,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
     "q_l = [1500.0, 0.0, 3000*patm]\n",
@@ -420,14 +459,21 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
-    "The density difference between the states is very small because water is almost incompressible. Note the small waves generated in the density plot and the very compressed rarefaction fan, which are consequences of the low compressibility of water."
+    "Note the small density difference accross left-going wave and the the very compressed rarefaction fan\n",
+    "are consequence of the low compressibility of water."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "### Problem 2: Transmission and reflection at an air-water interface\n",
     "We can use the Euler equations with the Tammann EOS to model wave propagation in almost-incompressible media, such as water. Since we have the solution for different EOS parameters in the left and right states, we can model interaction of different fluids across the interface. For instance, we can use this model to study the Riemann problem across an air-water interface. Air is modeled by the ideal gas EOS, which corresponds to $\\gamma=1.4$ and $p_{\\infty} = 0$, and water can be modeled using the same parameters as the example above. \n",
@@ -440,10 +486,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
-    "q_l = [1.0, 350.0, 2*patm] # Initial condition for shock in air\n",
+    "q_l = [1.0, 350.0, 300*patm] # Initial condition for shock in air\n",
     "q_r = [1000.0, 0.0, patm] # Initial condition in still water\n",
     "gamma = [gamma_air, gamma_water]\n",
     "pinf = [pinf_air, pinf_water]\n",
@@ -455,6 +504,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Note we exaggerated again the initial jump in pressure, so the jump in the density and velocity of the right-going wave could be appreciated in the plots; otherwise, it seems there is no jump in the right-going wave. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
     "### Problem 3: Water-air interface\n",
     "Here we consider a setup similar to that of Problem 2, but we invert the materials. The left region has water, while the right region has air."
    ]
@@ -462,10 +521,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
-    "q_l = [1000.0, 350.0, 2*patm] # Initial condition for shock in air\n",
+    "q_l = [1000.0, 350.0, 300*patm] # Initial condition for shock in air\n",
     "q_r = [1.0, 0.0, patm] # Initial condition in still water\n",
     "gamma = [gamma_water, gamma_air]\n",
     "pinf = [pinf_water, pinf_air]\n",
@@ -477,12 +539,25 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Once again we exaggerated the jump in pressure to be able to observe the jumps of the solution. Nonetheless, the density jump in the right-going wave is still not perceptible. A more exaggerated initial condition can make this jump more evident."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
     "## Strong rarefaction waves"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "As we mentioned when we introduced the Tammann EOS, the relevant physical quantities remain well-defined for \n",
     "negative pressures, as long as $p+p_{\\infty}>0$. For instance, the densities \\eqref{rho-k}, \\eqref{isentrop} and the sound speed \\eqref{sndsp} are all well defined in this case. This is consistent with the interpretation of the Tammann EOS as a shift of the zero pressure point of an ideal gas.\n",
@@ -493,7 +568,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": [
     "velocity = 350\n",
@@ -504,6 +582,13 @@
     "\n",
     "plot_riemann_solution(q_l, q_r, gamma, pinf);"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -522,7 +607,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "version": "2.7.13"
   }
  },
  "nbformat": 4,

--- a/Euler_equations_TammannEOS.ipynb
+++ b/Euler_equations_TammannEOS.ipynb
@@ -318,7 +318,7 @@
     "from ipywidgets import interact\n",
     "from ipywidgets import widgets\n",
     "import matplotlib.pyplot as plt\n",
-    "from exact_solvers import euler_tammann, interactive_pplanes\n",
+    "from exact_solvers import euler_tammann, interactive_pplanes, Euler\n",
     "from utils import riemann_tools"
    ]
   },
@@ -382,6 +382,7 @@
     "                                             reval, wave_types, \n",
     "                                             layout='vertical', \n",
     "                                             variable_names=varnames,\n",
+    "                                             aux=[gamma,pinf],\n",
     "                                             plot_chars=[euler_tammann.lambda1,\n",
     "                                                         euler_tammann.lambda2,\n",
     "                                                         euler_tammann.lambda3])\n",
@@ -502,7 +503,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "Note we exaggerated again the initial jump in pressure, so the jump in the density and velocity of the right-going wave could be appreciated in the plots; otherwise, it seems there is no jump in the right-going wave. "
    ]
@@ -537,7 +541,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "Once again we exaggerated the jump in pressure to be able to observe the jumps of the solution. Nonetheless, the density jump in the right-going wave is still not perceptible. A more exaggerated initial condition can make this jump more evident."
    ]
@@ -586,7 +593,20 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [],
    "source": []
   }

--- a/Euler_equations_TammannEOS.ipynb
+++ b/Euler_equations_TammannEOS.ipynb
@@ -318,7 +318,7 @@
     "from ipywidgets import interact\n",
     "from ipywidgets import widgets\n",
     "import matplotlib.pyplot as plt\n",
-    "from exact_solvers import euler_tammann, interactive_pplanes, Euler\n",
+    "from exact_solvers import euler_tammann, interactive_pplanes\n",
     "from utils import riemann_tools"
    ]
   },

--- a/exact_solvers/euler_tammann.py
+++ b/exact_solvers/euler_tammann.py
@@ -18,7 +18,7 @@ def primitive_to_conservative(rho, u, p, gamma, pinf):
     return rho, mom, E
 
 def conservative_to_primitive(rho, mom, E, gamma, pinf):
-    u = mom/rho
+    u = mom/pospart(rho)
     p = (gamma-1.)*(E - 0.5*rho*u**2) - gamma*pinf
     return rho, u, p
 
@@ -31,27 +31,42 @@ def sound_speed(rho, p, gamma = 1.4, pinf = 0.0):
 def alpha(rho, gamma):
     return 2.0/(pospart(rho)*(gamma + 1.0))
 
-def beta(p, gamma = 1.4, pinf = 0.0):
+def beta(p, gamma, pinf):
     return pospart(p + pinf)*(gamma - 1.0)/(gamma + 1.0)
 
-def lambda1(q, xi, gamma = 1.4, pinf = 0.0):
+def lambda1(q, xi, aux, varout='primitive'):
     "Characteristic speed for 1-waves."
-    rho, u, p = conservative_to_primitive(*q, gamma=gamma,pinf=pinf)
+    gamma = aux[0]
+    pinf = aux[1]
+    if varout == 'primitive':
+            rho, u, p = q
+    else:
+        rho, u, p = conservative_to_primitive(*q, gamma=gamma,pinf=pinf)
     al = alpha(rho, gamma)
     be = beta(p, gamma, pinf)
-    return u - np.sqrt((gamma*(pospart(p)+pinf+be)/al)/pospart(rho))
+    return u - np.sqrt(gamma*(p + pinf)/pospart(rho))
 
-def lambda2(q, xi, gamma = 1.4, pinf = 0.0):
+def lambda2(q, xi, aux, varout='primitive'):
     "Characteristic speed for 2-waves."
-    rho, u, p = conservative_to_primitive(*q, gamma=gamma,pinf=pinf)
+    gamma = aux[0]
+    pinf = aux[1]
+    if varout == 'primitive':
+            rho, u, p = q
+    else:
+        rho, u, p = conservative_to_primitive(*q, gamma=gamma,pinf=pinf)
     return u
 
-def lambda3(q, xi, gamma = 1.4, pinf = 0.0):
+def lambda3(q, xi, aux, varout='primitive'):
     "Characteristic speed for 3-waves."
-    rho, u, p = conservative_to_primitive(*q, gamma=gamma,pinf=pinf)
+    gamma = aux[0]
+    pinf = aux[1]
+    if varout == 'primitive':
+            rho, u, p = q
+    else:
+        rho, u, p = conservative_to_primitive(*q, gamma=gamma,pinf=pinf)
     al = alpha(rho, gamma)
     be = beta(p, gamma, pinf)
-    return u + np.sqrt((gamma*(pospart(p)+pinf+be)/al)/pospart(rho))
+    return u + np.sqrt(gamma*(p + pinf)/pospart(rho))
 
 def integral_curve_1(p, rhol, ul, pl, gammal = 1.4, pinfl = 0.0):
     """Velocity as a function of pressure for the 1-integral curve passing

--- a/utils/riemann_tools.py
+++ b/utils/riemann_tools.py
@@ -395,7 +395,7 @@ def make_plot_function(states_list,speeds_list,riemann_eval_list,
                 ax[1].legend(names,loc='best')
 
             if which_char:
-                plot_characteristics(riemann_eval,plot_chars[which_char-1],aux=aux,axes=ax[0])
+                plot_characteristics(riemann_eval,plot_chars[which_char-1],aux=aux,axes=ax[0], speeds=speeds)
 
         plt.show()
         return None
@@ -533,12 +533,12 @@ def plot_riemann_trajectories(x_traj, t_traj, s, wave_types=None, color='b',
 
     ax.set_title('Waves and particle trajectories in x-t plane')
 
-def plot_characteristics(reval, char_speed, aux=None, axes=None, extra_lines=None):
+def plot_characteristics(reval, char_speed, aux=None, axes=None, extra_lines=None, speeds=None):
     """
     Plot characteristics in x-t plane by integration.
 
     char_speed: Function char_speed(q,xi) that gives the characteristic speed.
-    aux: (aux_l, aux_r)
+    aux: (aux_l, aux_r) or list of duples [(aux_l,aux_r),...]
     axes: matplotlib axes on which to plot
     extra_lines: tuple of pairs of pairs; each entry specifies the endpoints of a line
                     along which to start more characteristics
@@ -559,7 +559,13 @@ def plot_characteristics(reval, char_speed, aux=None, axes=None, extra_lines=Non
         xi = chars[:,i-1]/max(t[i-1],dt)
         q = np.array(reval(xi))
         for j in range(len(x)):
-            if aux:
+            if type(aux) is list:
+                auxlist = []
+                cd_speed = speeds[1] # Assumes contact discontinuity is the second entry
+                for k in range(len(aux)):
+                    auxlist.append((xi[j]<=cd_speed)*aux[k][0]+(xi[j]>cd_speed)*aux[k][1])
+                c[j] = char_speed(q[:,j],xi[j],auxlist)
+            elif aux:
                 c[j] = char_speed(q[:,j],xi[j],(xi[j]<=0)*aux[0]+(xi[j]>0)*aux[1])
             else:
                 c[j] = char_speed(q[:,j],xi[j])


### PR DESCRIPTION
This fixed the plotting of the characteristics for the Tammann EOS notebook. I also added a couple more notes to explain the examples and change a couple of the parameters to make the jumps more visible. 

The main issue with the characteristics was that the Tammann EOS parameters were not passed to the functions that define the characteristics. To fix this, it required small modifications to riemann_tools.py, though it shouldn't break any previous functionality. Note that the characteristics now take into account that the jump in the EOS parameters is across the contact discontinuity and not across x=0.