### PR TITLE
Update to newer SIAM book style.

### DIFF
--- a/make_pdf.py
+++ b/make_pdf.py
@@ -67,6 +67,7 @@ os.system('cp *.cls '+build_dir)
 os.system('cp *.css '+build_dir)
 os.system('cp riemann.bib '+build_dir)
 os.system('cp latexdefs.tex '+build_dir)
+os.system('cp static/* '+build_dir)
 
 # fix interact import statements in exact_solver demo codes:
 os.chdir(os.path.join(build_dir, 'exact_solvers'))
@@ -109,7 +110,7 @@ for i, chapter in enumerate(chapters):
             #              r"sns.set_context('paper')", line)
             output.write(line)
     args = ["jupyter", "nbconvert", "--to", "notebook", "--execute",
-            "--ExecutePreprocessor.kernel_name=python2",
+            "--ExecutePreprocessor.kernel_name=python",
             "--output", output_filename,
             "--ExecutePreprocessor.timeout=60", build_dir+output_filename]
     subprocess.check_call(args)

--- a/riemann.tplx
+++ b/riemann.tplx
@@ -13,12 +13,45 @@
 
 ((* block predoc *))
     ((( super() )))
-    ((* block tableofcontents *))\tableofcontents((* endblock tableofcontents *))
+    ((* block tableofcontents *))
+        \frontmatter
+
+        \tableofcontents
+
+        \listoffigures
+
+        \listoftables
+
+        \mainmatter
+    ((* endblock tableofcontents *))
 ((* endblock predoc *))
 
 ((* block docclass *))
-\documentclass{SIAMGHbook2016}
+\documentclass[opener-c,final]{newsiambook}
 ((* endblock docclass *))
+
+((* block packages *))
+    \usepackage[T1]{fontenc}
+    \usepackage{amsmath} % Equations
+    \usepackage{amsfonts} % Equations
+
+    \usepackage{epsfig}
+    \usepackage{graphicx}
+    \usepackage{makeidx}
+    \usepackage{multicol}
+    \usepackage{subeqn}
+    \usepackage{crop}
+    \usepackage{xcolor} % Allow colors to be defined
+    \usepackage{fancyvrb} % verbatim replacement that allows latex
+    \usepackage{hyperref}
+    \usepackage{geometry} % Used to adjust the document margins
+    \usepackage{adjustbox} % Used to constrain images to a maximum size
+
+    \crop
+
+    \makeindex
+
+((* endblock packages *))
 
 ((* block author *))
 \author{David I. Ketcheson \and Randall J. LeVeque \and Mauricio del Razo Sarmina}

--- a/tex_style/crop.sty
+++ b/tex_style/crop.sty
@@ -1,0 +1,208 @@
+%%
+%% This is file `crop.sty',
+%% generated with the docstrip utility.
+%%
+%% The original source files were:
+%%
+%% crop.dtx  (with options: `package')
+%% 
+%% IMPORTANT NOTICE:
+%% 
+%% For the copyright see the source file.
+%% 
+%% You are *not* allowed to modify this file.
+%% 
+%% You are *not* allowed to distribute this file.
+%% For distribution of the original source see the terms
+%% for copying and modification in the file crop.dtx.
+%% 
+%% File: crop.dtx   Copyright (C) 1998,1999    Melchior FRANZ
+\NeedsTeXFormat{LaTeX2e}
+\ProvidesPackage{crop}[1999/05/15 v1.3a cropmarks  (mf)]
+\DeclareOption{landscapecenter}{%
+  \def\CROP@center#1#2{\AtBeginDocument{\CROP@setoffset{#2}{#1}}}}
+\DeclareOption{a4center}{\CROP@center{297truemm}{210truemm}}
+\DeclareOption{a5center}{\CROP@center{210truemm}{148truemm}}
+\DeclareOption{b5center}{\CROP@center{250truemm}{176truemm}}
+\DeclareOption{lettercenter}{\CROP@center{11truein}{8.5truein}}
+\DeclareOption{sevenbyten}{\CROP@center{10truein}{7truein}}
+\DeclareOption{legalcenter}{\CROP@center{14truein}{8.5truein}}
+\DeclareOption{executivecenter}{\CROP@center{10.5truein}{7.25truein}}
+\newcommand*\CROP@setoffset[2]{%
+  \voffset#1\advance\voffset-\paperheight\voffset.5\voffset
+  \hoffset#2\advance\hoffset-\paperwidth\hoffset.5\hoffset}
+\def\CROP@center#1#2{\AtBeginDocument{\CROP@setoffset{#1}{#2}}}
+\DeclareOption*{\CROP@execopt\CurrentOption}
+\newcommand*\crop[1][cam,noaxes]{%
+  \@for\CROP@@:=#1\do{\CROP@execopt\CROP@@}}
+\newcommand*\CROP@execopt[1]{%
+  \def\CROP@##1=##2=##3\@nil{\def\CROP@{##1}\def\CROP@@{##2}}%
+  \expandafter\CROP@#1==\@nil%
+  \@ifundefined{CROP@opt@\CROP@}%
+    {\PackageWarning{crop}{Requested option `#1' not provided}}%
+      {\@nameuse{CROP@opt@\CROP@}}}
+\newcommand*\cropdef[6][\CROP@@info]{%
+  \@namedef{CROP@opt@#6}{%
+    \CROP@on
+    \def\CROP@info{#1}%
+    \let\CROP@ulc#2
+    \let\CROP@urc#3
+    \let\CROP@llc#4
+    \let\CROP@lrc#5}}
+\newcommand*\CROP@@vaxis{%
+  \hfil
+  \setbox\z@\hbox{\vtop{\hrule\@height12\p@\@depth-2\p@\@width.4\p@
+    \vskip\paperheight\vskip4\p@
+    \hrule\@height\z@\@depth10\p@\@width.4\p@}}%
+  \ht\z@\z@ \dp\z@\z@ \box\z@
+  \hfil}
+\newcommand*\CROP@@haxis{%
+  \vfil
+  \hb@xt@\paperwidth{%
+    \llap{\vrule\@height.2\p@\@depth.2\p@\@width10\p@\hskip2\p@}%
+    \hfil
+    \rlap{\hskip2\p@\vrule\@height.2\p@\@depth.2\p@\@width10\p@}}%
+  \vfil}
+\newcommand*\CROP@@info{%
+  \hskip\paperwidth\hskip12\p@
+  \raise12\p@\hbox{\vbox{%
+    \hbox{``\jobname''\strut}%
+    \hbox{\the\year/\the\month/\the\day\strut}%
+    \hbox{page \thepage\strut}}}}
+\newcommand*\CROP@@ulc{%
+  \begin{picture}(0,0)\unitlength\p@\thinlines
+  \put(-30,0){\circle{10}}
+  \put(-30,-5){\line(0,1){10}}
+  \put(-35,0){\line(1,0){30}}
+  \put(0,30){\circle{10}}
+  \put(-5,30){\line(1,0){10}}
+  \put(0,35){\line(0,-1){30}}
+  \end{picture}}
+\newcommand*\CROP@@urc{%
+  \begin{picture}(0,0)\unitlength\p@\thinlines
+  \put(30,0){\circle{10}}
+  \put(30,-5){\line(0,1){10}}
+  \put(35,0){\line(-1,0){30}}
+  \put(0,30){\circle{10}}
+  \put(-5,30){\line(1,0){10}}
+  \put(0,35){\line(0,-1){30}}
+  \end{picture}}
+\newcommand*\CROP@@llc{%
+  \begin{picture}(0,0)\unitlength\p@\thinlines
+  \put(-30,0){\circle{10}}
+  \put(-30,-5){\line(0,1){10}}
+  \put(-35,0){\line(1,0){30}}
+  \put(0,-30){\circle{10}}
+  \put(-5,-30){\line(1,0){10}}
+  \put(0,-35){\line(0,1){30}}
+  \end{picture}}
+\newcommand*\CROP@@lrc{%
+  \begin{picture}(0,0)\unitlength\p@\thinlines
+  \put(30,0){\circle{10}}
+  \put(30,-5){\line(0,1){10}}
+  \put(35,0){\line(-1,0){30}}
+  \put(0,-30){\circle{10}}
+  \put(-5,-30){\line(1,0){10}}
+  \put(0,-35){\line(0,1){30}}
+  \end{picture}}
+\cropdef\CROP@@ulc\CROP@@urc\CROP@@llc\CROP@@lrc{cam}
+\newcommand*\CROP@@cross{%
+  \begin{picture}(0,0)\unitlength1in\thinlines
+    \put(-1,0){\line(1,0){2}}
+    \put(0,-1){\line(0,1){2}}
+  \end{picture}}
+\cropdef\CROP@@cross\CROP@@cross\CROP@@cross\CROP@@cross{cross}
+\newcommand*\CROP@@frame{%
+  \begin{picture}(0,0)\unitlength\p@\thinlines
+    \put(0,0){\line(1,0){\strip@pt\paperwidth}}
+    \put(0,0){\line(0,-1){\strip@pt\paperheight}}
+    \put(\strip@pt\paperwidth,0){\line(0,-1){\strip@pt\paperheight}}
+    \put(0,-\strip@pt\paperheight){\line(1,0){\strip@pt\paperwidth}}
+  \end{picture}}
+\cropdef\CROP@@frame\relax\relax\relax{frame}
+\let\CROP@shipout\shipout
+\renewcommand*\shipout{\afterassignment\CROP@ship\setbox\@cclv=}
+\newcommand*\CROP@ship{%
+  \ifvoid\@cclv\expandafter\aftergroup\fi\CROP@@ship}
+\newcommand*\CROP@shiplist{\CROP@@@ship\unvbox\@cclv}
+\newcommand*\CROP@@ship{\CROP@shipout\vbox{\CROP@shiplist}}
+\newcommand*\CROP@shipadd[1]{\begingroup
+  \toks@\expandafter{\expandafter#1\expandafter{\CROP@shiplist}}%
+  \xdef\CROP@shiplist{\the\toks@}%
+  \endgroup}
+\newcommand*\CROP@kernel{\color@setgroup
+  \vbox to\z@{\vskip-.5in%_%_%_%_%_%moves crops relative to page
+    \hb@xt@\z@{\hskip-.25in
+      \CROP@every
+      \vbox to\paperheight{%
+        \hb@xt@\paperwidth{%
+          \setbox\z@\hbox{\normalfont\CROP@info}%
+          \ht\z@\z@ \dp\z@\z@ \wd\z@\z@ \box\z@
+          \CROP@ulc\CROP@uedge\CROP@urc}%
+        \CROP@ledge
+        \hb@xt@\paperwidth{%
+          \CROP@llc\hfil\CROP@lrc}}%
+    \hss}%
+  \vss}\color@endgroup}
+\newcommand*\CROP@on{\let\CROP@@@ship\CROP@kernel}
+\newcommand*\CROP@opt@off{\let\CROP@@@ship\relax}
+\newcommand*\CROP@opt@axes{%
+  \let\CROP@uedge\CROP@@vaxis
+  \let\CROP@ledge\CROP@@haxis}
+\newcommand*\CROP@opt@noaxes{%
+  \let\CROP@uedge\hfil
+  \let\CROP@ledge\vfil}
+\expandafter\newcommand\expandafter*\csname CROP@opt@mount1\endcsname
+  {\let\CROP@every\relax}
+\newcount\CROP@offset
+\expandafter\newcommand\expandafter*\csname CROP@opt@mount2\endcsname
+  {\CROP@offset=\ifx\CROP@@\empty\z@\else\CROP@@\fi
+  \def\CROP@every{\count@\c@page
+    \advance\count@\CROP@offset
+    \ifodd\count@
+      \let\CROP@ulc\relax\let\CROP@llc\relax
+    \else
+      \let\CROP@urc\relax\let\CROP@lrc\relax\let\CROP@info\relax
+    \fi}}
+\DeclareOption{mirror}{%
+  \AtBeginDocument{\CROP@shipadd\CROP@reflect\CROP@setps}}
+\newcommand*\CROP@reflect[1]{%
+  \vbox to\z@{\vskip-1in\hb@xt@\z@{\hskip-1in
+    \CROP@ps{gsave currentpoint}\kern\paperwidth
+    \CROP@ps{currentpoint}\hss}\vss}%
+  \CROP@ps{translate -1 1 scale neg exch neg exch translate}%
+  \vbox{#1}%
+  \CROP@ps{grestore}}
+\newcommand*\CROP@setps{%
+  \ifx\Gin@PS@raw\undefined
+    \PackageWarning{crop}{internal PostScript interface used}%
+    \newcommand*\CROP@ps[1]{\special{ps: ##1}}%
+  \else
+    \PackageInfo{crop}{graphics/color PostScript interface used}{}%
+    \let\CROP@ps\Gin@PS@raw
+  \fi
+  \let\CROP@setps\undefined}
+\DeclareOption{invert}{%
+  \AtEndOfPackage{\RequirePackage{color}}%
+  \AtBeginDocument{\CROP@invert}}
+\newcommand*\CROP@invert{%
+  \ifx\color\undefined
+    \PackageWarning{crop}%
+      {The `color' package could not be loaded,^^J%
+      so I'm ignoring the `invert' option}%
+  \else
+    \pagecolor{black}\color{white}%
+    \newcommand\CROP@color[2][]{}%
+    \DeclareRobustCommand\color{\CROP@color}%
+    \DeclareRobustCommand\pagecolor{\CROP@color}%
+    \DeclareRobustCommand\textcolor{\CROP@color}%
+    \let\normalcolor\relax
+  \fi
+  \let\CROP@invert\undefined}
+\crop[off,noaxes,mount1]
+\InputIfFileExists{crop.cfg}%
+  {\PackageInfo{crop}{Local config file crop.cfg used}}{}
+\ProcessOptions
+\endinput
+%%
+%% End of file `crop.sty'.

--- a/tex_style/ly1poptima.fd
+++ b/tex_style/ly1poptima.fd
@@ -1,0 +1,66 @@
+
+
+\ProvidesFile{ly1poptima.fd}
+   [1997/01/26  LY1/poptima with Adobe file names. (DPC)]
+
+\DeclareFontFamily{LY1}{poptima}{}
+
+\DeclareFontShape{LY1}{poptima}{b}{n}{
+   <-> opb
+}{}
+
+\DeclareFontShape{LY1}{poptima}{b}{sc}{
+   <-> sub poptima/b/n
+}{}
+
+\DeclareFontShape{LY1}{poptima}{b}{sl}{
+   <-> opbi
+}{}
+
+\DeclareFontShape{LY1}{poptima}{bc}{n}{
+   <-> sub poptima/m/n
+}{}
+
+\DeclareFontShape{LY1}{poptima}{bc}{sc}{
+   <-> sub poptima/bc/n
+}{}
+
+\DeclareFontShape{LY1}{poptima}{bc}{sl}{
+   <-> sub poptima/m/sl
+}{}
+
+\DeclareFontShape{LY1}{poptima}{m}{n}{
+   <-> op
+}{}
+
+\DeclareFontShape{LY1}{poptima}{m}{sc}{
+   <-> sub poptima/m/n
+}{}
+
+\DeclareFontShape{LY1}{poptima}{m}{sl}{
+   <-> opi
+}{}
+
+\DeclareFontShape{LY1}{poptima}{mc}{n}{
+   <-> sub poptima/m/m
+}{}
+
+\DeclareFontShape{LY1}{poptima}{mc}{sc}{
+   <-> sub poptima/m/n
+}{}
+
+\DeclareFontShape{LY1}{poptima}{mc}{sl}{
+   <-> sub poptima/m/sl
+}{}
+
+\DeclareFontShape{LY1}{poptima}{bx}{n}{<->ssub * poptima/b/n}{}
+\DeclareFontShape{LY1}{poptima}{bx}{sc}{<->ssub * poptima/b/sc}{}
+\DeclareFontShape{LY1}{poptima}{bx}{sl}{<->ssub * poptima/b/sl}{}
+\DeclareFontShape{LY1}{poptima}{b}{it}{<->ssub * poptima/b/sl}{}
+\DeclareFontShape{LY1}{poptima}{bx}{it}{<->ssub * poptima/b/it}{}
+\DeclareFontShape{LY1}{poptima}{bc}{it}{<->ssub * poptima/bc/sl}{}
+\DeclareFontShape{LY1}{poptima}{l}{it}{<->ssub * poptima/l/sl}{}
+\DeclareFontShape{LY1}{poptima}{m}{it}{<->ssub * poptima/m/sl}{}
+\DeclareFontShape{LY1}{poptima}{mc}{it}{<->ssub * poptima/mc/sl}{}
+
+\endinput

--- a/tex_style/newsiambk10.clo
+++ b/tex_style/newsiambk10.clo
@@ -1,0 +1,195 @@
+\ProvidesFile{newsiambk10.clo}
+              [2000/05/03 v1.5
+      Customized LaTeX file (size option)]
+\renewcommand\normalsize{%
+   \@setfontsize\normalsize\@xpt\@xiipt
+   \abovedisplayskip 10\p@ \@plus2\p@ \@minus5\p@
+   \abovedisplayshortskip \z@ \@plus3\p@
+   \belowdisplayshortskip 6\p@ \@plus3\p@ \@minus3\p@
+   \belowdisplayskip \abovedisplayskip
+   \let\@listi\@listI}
+\normalsize
+\newcommand\small{%
+   \@setfontsize\small\@ixpt{11}%
+   \abovedisplayskip 8.5\p@ \@plus3\p@ \@minus4\p@
+   \abovedisplayshortskip \z@ \@plus2\p@
+   \belowdisplayshortskip 4\p@ \@plus2\p@ \@minus2\p@
+   \def\@listi{\leftmargin\leftmargini
+               \topsep 4\p@ \@plus2\p@ \@minus2\p@
+               \parsep 2\p@ \@plus\p@ \@minus\p@
+               \itemsep \parsep}%
+   \belowdisplayskip \abovedisplayskip
+}
+\newcommand\footnotesize{%
+   \@setfontsize\footnotesize\@viiipt{9.5}%
+   \abovedisplayskip 6\p@ \@plus2\p@ \@minus4\p@
+   \abovedisplayshortskip \z@ \@plus\p@
+   \belowdisplayshortskip 3\p@ \@plus\p@ \@minus2\p@
+   \def\@listi{\leftmargin\leftmargini
+               \topsep 3\p@ \@plus\p@ \@minus\p@
+               \parsep 2\p@ \@plus\p@ \@minus\p@
+               \itemsep \parsep}%
+   \belowdisplayskip \abovedisplayskip
+}
+\newcommand\scriptsize{\@setfontsize\scriptsize\@viipt\@viiipt}
+\newcommand\tiny{\@setfontsize\tiny\@vpt\@vipt}
+\newcommand\large{\@setfontsize\large\@xiipt{14}}
+\newcommand\Large{\@setfontsize\Large\@xivpt{18}}
+\newcommand\LARGE{\@setfontsize\LARGE\@xviipt{22}}
+\newcommand\huge{\@setfontsize\huge\@xxpt{25}}
+\newcommand\Huge{\@setfontsize\Huge\@xxvpt{30}}
+\if@twocolumn
+  \setlength\parindent{1em}
+\else
+  \setlength\parindent{24\p@}
+\fi
+\setlength\smallskipamount{3\p@ \@plus 1\p@ \@minus 1\p@}
+\setlength\medskipamount{6\p@ \@plus 2\p@ \@minus 2\p@}
+\setlength\bigskipamount{12\p@ \@plus 4\p@ \@minus 4\p@}
+\setlength\headheight{12\p@}
+\setlength\headsep   {.25in}
+\setlength\topskip   {10\p@}
+\setlength\footskip{.35in}
+\if@compatibility \setlength\maxdepth{4\p@} \else
+\setlength\maxdepth{.5\topskip} \fi
+\if@compatibility
+  \if@twocolumn
+    \setlength\textwidth{5in}
+  \else
+    \setlength\textwidth{5in}
+  \fi
+\else
+  \setlength\@tempdima{\paperwidth}
+  \addtolength\@tempdima{-2in}
+  \setlength\@tempdimb{5in}
+  \if@twocolumn
+    \ifdim\@tempdima>2\@tempdimb\relax
+      \setlength\textwidth{2\@tempdimb}
+    \else
+      \setlength\textwidth{\@tempdima}
+    \fi
+  \else
+    \ifdim\@tempdima>\@tempdimb\relax
+      \setlength\textwidth{\@tempdimb}
+    \else
+      \setlength\textwidth{\@tempdima}
+    \fi
+  \fi
+\fi
+\if@compatibility\else
+  \@settopoint\textwidth
+\fi
+\if@compatibility
+  \setlength\textheight{41\baselineskip}
+\else
+  \setlength\@tempdima{\paperheight}
+  \addtolength\@tempdima{-2in}
+  \addtolength\@tempdima{-1.5in}
+  \divide\@tempdima\baselineskip
+  \@tempcnta=\@tempdima
+  \setlength\textheight{\@tempcnta\baselineskip}
+\fi
+\addtolength\textheight{\topskip}
+\if@twocolumn
+ \setlength\marginparsep {10\p@}
+\else
+  \setlength\marginparsep{7\p@}
+\fi
+\setlength\marginparpush{5\p@}
+\if@compatibility
+   \setlength\oddsidemargin   {.5in}
+   \setlength\evensidemargin  {1.5in}
+   \setlength\marginparwidth {.75in}
+  \if@twocolumn
+     \setlength\oddsidemargin  {30\p@}
+     \setlength\evensidemargin {30\p@}
+     \setlength\marginparwidth {48\p@}
+  \fi
+\else
+  \if@twoside
+    \setlength\@tempdima        {\paperwidth}
+    \addtolength\@tempdima      {-\textwidth}
+    \setlength\oddsidemargin    {.4\@tempdima}
+    \addtolength\oddsidemargin  {-1in}
+    \setlength\marginparwidth   {.6\@tempdima}
+    \addtolength\marginparwidth {-\marginparsep}
+    \addtolength\marginparwidth {-0.4in}
+  \else
+    \setlength\@tempdima        {\paperwidth}
+    \addtolength\@tempdima      {-\textwidth}
+    \setlength\oddsidemargin    {.5\@tempdima}
+    \addtolength\oddsidemargin  {-1in}
+    \setlength\marginparwidth   {.5\@tempdima}
+    \addtolength\marginparwidth {-\marginparsep}
+    \addtolength\marginparwidth {-0.4in}
+    \addtolength\marginparwidth {-.4in}
+  \fi
+  \ifdim \marginparwidth >2in
+     \setlength\marginparwidth{2in}
+  \fi
+  \@settopoint\oddsidemargin
+  \@settopoint\marginparwidth
+  \setlength\evensidemargin  {\paperwidth}
+  \addtolength\evensidemargin{-2in}
+  \addtolength\evensidemargin{-\textwidth}
+  \addtolength\evensidemargin{-\oddsidemargin}
+  \@settopoint\evensidemargin
+\fi
+\if@compatibility
+  \setlength\topmargin{.75in}
+\else
+  \setlength\topmargin{\paperheight}
+  \addtolength\topmargin{-2in}
+  \addtolength\topmargin{-\headheight}
+  \addtolength\topmargin{-\headsep}
+  \addtolength\topmargin{-\textheight}
+  \addtolength\topmargin{-\footskip}     % this might be wrong!
+  \addtolength\topmargin{-.5\topmargin}
+  \@settopoint\topmargin
+\fi
+\setlength\footnotesep{6.65\p@}
+\setlength{\skip\footins}{9\p@ \@plus 4\p@ \@minus 2\p@}
+\setlength\floatsep    {12\p@ \@plus 2\p@ \@minus 2\p@}
+\setlength\textfloatsep{20\p@ \@plus 2\p@ \@minus 4\p@}
+\setlength\intextsep   {12\p@ \@plus 2\p@ \@minus 2\p@}
+\setlength\dblfloatsep    {12\p@ \@plus 2\p@ \@minus 2\p@}
+\setlength\dbltextfloatsep{20\p@ \@plus 2\p@ \@minus 4\p@}
+\setlength\@fptop{0\p@ \@plus 1fil}
+\setlength\@fpsep{8\p@ \@plus 2fil}
+\setlength\@fpbot{0\p@ \@plus 1fil}
+\setlength\@dblfptop{0\p@ \@plus 1fil}
+\setlength\@dblfpsep{8\p@ \@plus 2fil}
+\setlength\@dblfpbot{0\p@ \@plus 1fil}
+\setlength\partopsep{2\p@ \@plus 1\p@ \@minus 1\p@}
+\def\@listi{\leftmargin\leftmargini
+            \parsep 4\p@ \@plus2\p@ \@minus\p@
+            \topsep 8\p@ \@plus2\p@ \@minus4\p@
+            \itemsep4\p@ \@plus2\p@ \@minus\p@}
+\let\@listI\@listi
+\@listi
+\def\@listii {\leftmargin\leftmarginii
+              \labelwidth\leftmarginii
+              \advance\labelwidth-\labelsep
+              \topsep    4\p@ \@plus2\p@ \@minus\p@
+              \parsep    2\p@ \@plus\p@  \@minus\p@
+              \itemsep   \parsep}
+\def\@listiii{\leftmargin\leftmarginiii
+              \labelwidth\leftmarginiii
+              \advance\labelwidth-\labelsep
+              \topsep    2\p@ \@plus\p@\@minus\p@
+              \parsep    \z@
+              \partopsep \p@ \@plus\z@ \@minus\p@
+              \itemsep   \topsep}
+\def\@listiv {\leftmargin\leftmarginiv
+              \labelwidth\leftmarginiv
+              \advance\labelwidth-\labelsep}
+\def\@listv  {\leftmargin\leftmarginv
+              \labelwidth\leftmarginv
+              \advance\labelwidth-\labelsep}
+\def\@listvi {\leftmargin\leftmarginvi
+              \labelwidth\leftmarginvi
+              \advance\labelwidth-\labelsep}
+\setlength{\textwidth}{5in}
+\endinput
+%%
+%% End of file `bk10.clo'.

--- a/tex_style/newsiambook.cls
+++ b/tex_style/newsiambook.cls
@@ -1,0 +1,1204 @@
+%% Revised 2012/04/26 to automatically load citeref package; class option [nociteref]
+%% Revised 2001/10/10 to correct algorithms: xreferencing,numbering
+%% Revised 2002/02/19 to correct optional title in algorithms
+%% Revised 2002/05/01 to force footnotes to number consecutively throughout book
+%% Revised 2003/10/21 added example environment, like theorem
+%% Revised 2008/10/21 to correct algorithm counter stepping
+\NeedsTeXFormat{LaTeX2e}[1995/12/01]
+\ProvidesClass{newsiambook}
+              [2003/10/22 v1.9
+ Customized LaTeX document class]
+\newcommand\@ptsize{}
+\newif\if@restonecol
+\newif\if@titlepage
+\@titlepagetrue
+\newif\if@openright
+\newif\if@mainmatter \@mainmattertrue
+\if@compatibility\else
+\newif\if@onethmnum
+\@onethmnumfalse
+%_%_%_%_% remove theorem numbering from class???
+\newif\if@mytheorems
+\@mytheoremsfalse
+
+
+
+%%%%add formatted authors to chapter opener...
+\newenvironment{authorline}{\let\thanks\footnote\renewcommand{\thefootnote}{\fnsymbol{footnote}}%
+\Large\bfseries\itshape}{\vskip36pt\setcounter{footnote}{0}}
+
+%%%%add author names to table of contents...
+\newcommand{\authortoc}[1]{\addtocontents{toc}{\hspace*{-.5em}{\bfseries\itshape #1}}}
+
+%_%_%_%default "plain" chapter opener...no graphic
+\DeclareOption{plain-opener}{%
+\def\@makechapterhead#1{%
+   {\parindent \z@ \raggedright \normalfont
+    \ifnum \c@secnumdepth >\m@ne
+      \if@mainmatter     
+%
+\noindent{\setlength{\unitlength}{1pt}\begin{picture}(360,144)
+\put(0,22.5){\setlength{\fboxsep}{0pt}%\fbox
+{\parbox[b][99pt][c]{300pt}{\raggedright\sffamily\Large\bfseries%
+\@chapapp\space \thechapter
+        \vskip3pt\par\nobreak
+    \Huge \bfseries #1\par}}}%%end of parbox and put
+\end{picture}}
+ \fi
+    \fi
+    \interlinepenalty\@M}   \vskip 40\p@
+  }%
+\def\@part[#1]#2{%
+    \ifnum \c@secnumdepth >-2\relax
+      \refstepcounter{part}%
+      \addcontentsline{toc}{part}{\hbox to 20pt{\thepart}#1}%
+    \else
+      \addcontentsline{toc}{part}{#1}%
+    \fi
+    \markboth{}{}%
+    {\centering
+     \interlinepenalty \@M
+     \normalfont
+    %_%_%_%_%add part background graphic...
+ \ifnum \c@secnumdepth >-2\relax
+       \sffamily\huge\bfseries \partname~\thepart
+       \par
+       \vskip 20\p@
+     \fi
+     \sffamily\Huge \bfseries #2\par}%
+    \@endpart}}
+\DeclareOption{opener-d}{%
+%_%_%_%_% new makechapterhead
+%_%_%_%_% type "D"
+%_%_%_%_%
+\def\@makechapterhead#1{%
+   {\parindent \z@ \raggedright \normalfont
+    \ifnum \c@secnumdepth >\m@ne
+      \if@mainmatter     
+%
+\noindent{\setlength{\unitlength}{1pt}\begin{picture}(360,144)
+\put(0,11){\includegraphics[height=120pt]{macroa-1-gray.eps}}
+\put(72,22.5){\setlength{\fboxsep}{0pt}%\fbox
+{\parbox[b][99pt][c]{300pt}{\raggedright\sffamily\Large\bfseries%
+\@chapapp\space \thechapter
+        \vskip3pt\par\nobreak
+    \Huge \bfseries #1\par}}}%%end of parbox and put
+\end{picture}}
+ \fi
+    \fi
+    \interlinepenalty\@M}   \vskip 40\p@
+  }%
+\def\@part[#1]#2{%
+    \ifnum \c@secnumdepth >-2\relax
+      \refstepcounter{part}%
+      \addcontentsline{toc}{part}{\hbox to 20pt{\thepart}#1}%
+    \else
+      \addcontentsline{toc}{part}{#1}%
+    \fi
+    \markboth{}{}%
+         \interlinepenalty \@M
+     \normalfont
+    %_%_%_%_%add part background graphic...
+ \ifnum \c@secnumdepth >-2\relax
+\noindent{\setlength{\unitlength}{1pt}\begin{picture}(360,144)
+\put(0,11){\includegraphics[height=120pt]{macroa-1-gray.eps}}
+\put(72,22.5){\setlength{\fboxsep}{0pt}%\fbox
+{\parbox[b][99pt][c]{300pt}{\parindent0pt\sffamily\Large\bfseries%
+\partname\space \thepart
+        \vskip3pt\par\nobreak
+    \Huge \bfseries #2\par}}}%%end of parbox and put
+\end{picture}}
+     \fi
+    \@endpart}}
+\DeclareOption{opener-c}{%
+
+%_%_%_%_% new makechapterhead
+%_%_%_%_% type "C"
+%_%_%_%_%
+\def\@makechapterhead#1{%
+   {\parindent \z@ \raggedright \normalfont
+    \ifnum \c@secnumdepth >\m@ne
+      \if@mainmatter     
+%
+\noindent{\setlength{\unitlength}{1pt}\begin{picture}(360,144)
+\put(0,0){\includegraphics[width=114pt]{macroa2-gray.eps}}
+\put(118,16){\vbox to 99pt{\hsize247pt\raggedright\sffamily\Large\bfseries%
+\vfill\@chapapp\space \thechapter
+        \vskip3pt\par\nobreak
+    \huge \bfseries #1\par\vfill}}%%end of parbox and put
+\end{picture}}
+ \fi
+    \fi
+    \interlinepenalty\@M}   \vskip 40\p@
+  }%
+\def\@part[#1]#2{%
+    \ifnum \c@secnumdepth >-2\relax
+      \refstepcounter{part}%
+      \addcontentsline{toc}{part}{\hbox to 20pt{\thepart}#1}%
+    \else
+      \addcontentsline{toc}{part}{#1}%
+    \fi
+    \markboth{}{}%
+         \interlinepenalty \@M
+     \normalfont
+    %_%_%_%_%add part background graphic...
+ \ifnum \c@secnumdepth >-2\relax
+\noindent{\setlength{\unitlength}{1pt}\begin{picture}(360,144)
+\put(0,0){\includegraphics[width=114pt]{macroa2-gray.eps}}
+\put(118,16){\vbox to 99pt{\hsize247pt\parindent0pt\sffamily\Large\bfseries%
+\vfill\partname\space \thepart
+        \vskip3pt\par\nobreak
+    \huge \bfseries #2\par\vfill}}%%end of parbox and put
+\end{picture}}
+     \fi
+    \@endpart}}
+\DeclareOption{opener-b}{%
+%_%_%_%_% new makechapterhead
+%_%_%_%_% type "B"
+%_%_%_%_%
+\def\@makechapterhead#1{%
+   {\parindent \z@ \raggedright \normalfont
+    \ifnum \c@secnumdepth >\m@ne
+      \if@mainmatter     
+%
+\noindent{\setlength{\unitlength}{1pt}\begin{picture}(360,144)
+\put(0,0){\includegraphics[width=114pt]{macroa2-gray.eps}}
+\put(118,16){\vbox to 99pt{\hsize247pt\raggedright\sffamily\Large\bfseries%
+\@chapapp\space \thechapter
+        \vskip3pt\par\vfill\nobreak
+    \huge \bfseries #1\par}}%%end of parbox and put
+\end{picture}}
+ \fi
+    \fi
+    \interlinepenalty\@M}   \vskip 40\p@
+  }%
+\def\@part[#1]#2{%
+    \ifnum \c@secnumdepth >-2\relax
+      \refstepcounter{part}%
+      \addcontentsline{toc}{part}{\hbox to 20pt{\thepart}#1}%
+    \else
+      \addcontentsline{toc}{part}{#1}%
+    \fi
+    \markboth{}{}%
+         \interlinepenalty \@M
+     \normalfont
+    %_%_%_%_%add part background graphic...
+ \ifnum \c@secnumdepth >-2\relax
+\noindent{\setlength{\unitlength}{1pt}\begin{picture}(360,144)
+\put(0,0){\includegraphics[width=114pt]{macroa2-gray.eps}}
+\put(118,16){\vbox to 99pt{\parindent0pt\hsize247pt\sffamily\Large\bfseries%
+\partname\space \thepart
+        \vskip3pt\par\vfill\nobreak
+    \huge \bfseries #2\par}}%%end of parbox and put
+\end{picture}}
+     \fi
+    \@endpart}}
+
+\DeclareOption{opener-a}{%
+%_%_%_%_% new makechapterhead...
+%_%_%_%_% type "A"
+%_%_%_%_%
+\def\@makechapterhead#1{%
+   {\parindent \z@ \raggedright \normalfont
+    \ifnum \c@secnumdepth >\m@ne
+      \if@mainmatter     
+%
+\noindent{\setlength{\unitlength}{1pt}\begin{picture}(360,144)
+\put(0,-1){\includegraphics[height=102pt]{macroa-gray.eps}}
+\put(118,0){\vbox to 100pt{\hsize247pt\raggedright\sffamily\Large\bfseries%
+\@chapapp\space \thechapter
+        \vfill\par\nobreak
+    \huge \bfseries #1\par}}%%end of parbox and put
+\end{picture}}
+ \fi
+    \fi
+    \interlinepenalty\@M}   \vskip 40\p@
+  }%
+\def\@part[#1]#2{%
+    \ifnum \c@secnumdepth >-2\relax
+      \refstepcounter{part}%
+      \addcontentsline{toc}{part}{\thepart\hspace{10em}#1}%
+    \else
+      \addcontentsline{toc}{part}{#1}%
+    \fi
+    \markboth{}{}%
+         \interlinepenalty \@M
+     \normalfont
+    %_%_%_%_%add part background graphic...
+ \ifnum \c@secnumdepth >-2\relax
+\noindent{\setlength{\unitlength}{1pt}\begin{picture}(360,144)
+\put(0,-1){\includegraphics[height=102pt]{macroa-gray.eps}}
+\put(118,0){\vbox to 100pt{\parindent0pt\hsize247pt\sffamily\Large\bfseries%
+\partname\space \thepart
+        \vfill\par\nobreak
+    \huge \bfseries #2\par}}%%end of parbox and put
+\end{picture}}
+     \fi
+    \@endpart}}
+\DeclareOption{a4paper}
+   {\setlength\paperheight {297mm}%
+    \setlength\paperwidth  {210mm}}
+\DeclareOption{a5paper}
+   {\setlength\paperheight {210mm}%
+    \setlength\paperwidth  {148mm}}
+\DeclareOption{b5paper}
+   {\setlength\paperheight {250mm}%
+    \setlength\paperwidth  {176mm}}
+\DeclareOption{letterpaper}
+   {\setlength\paperheight {11in}%
+    \setlength\paperwidth  {8.5in}}
+\DeclareOption{legalpaper}
+   {\setlength\paperheight {14in}%
+    \setlength\paperwidth  {8.5in}}
+\DeclareOption{executivepaper}
+   {\setlength\paperheight {10.5in}%
+    \setlength\paperwidth  {7.25in}}
+\DeclareOption{landscape}
+   {\setlength\@tempdima   {\paperheight}%
+    \setlength\paperheight {\paperwidth}%
+    \setlength\paperwidth  {\@tempdima}}
+\fi
+\if@compatibility
+  \renewcommand\@ptsize{0}
+\else
+\DeclareOption{10pt}{\renewcommand\@ptsize{0}}
+\fi
+\DeclareOption{11pt}{\renewcommand\@ptsize{1}}
+\DeclareOption{12pt}{\renewcommand\@ptsize{2}}
+\if@compatibility\else
+\DeclareOption{oneside}{\@twosidefalse \@mparswitchfalse}
+\fi
+\DeclareOption{twoside}{\@twosidetrue  \@mparswitchtrue}
+\DeclareOption{draft}{\setlength\overfullrule{5pt}}
+\if@compatibility\else
+\DeclareOption{final}{\setlength\overfullrule{0pt}}
+\fi
+\DeclareOption{titlepage}{\@titlepagetrue}
+\if@compatibility\else
+\DeclareOption{notitlepage}{\@titlepagefalse}
+\fi
+\if@compatibility
+\@openrighttrue
+\else
+\DeclareOption{openright}{\@openrighttrue}
+\DeclareOption{openany}{\@openrightfalse}
+\fi
+\if@compatibility\else
+\DeclareOption{onecolumn}{\@twocolumnfalse}
+\fi
+\DeclareOption{twocolumn}{\@twocolumntrue}
+\DeclareOption{leqno}{\input{leqno.clo}}
+\DeclareOption{fleqn}{\input{fleqn.clo}}
+\DeclareOption{openbib}{%
+  \AtEndOfPackage{%
+   \renewcommand\@openbib@code{%
+      \advance\leftmargin\bibindent
+      \itemindent -\bibindent
+      \listparindent \itemindent
+      \parsep \z@
+      }%
+   \renewcommand\newblock{\par}}%
+}
+\DeclareOption{onethmnum}{\@onethmnumtrue} % added 7.29.96
+\DeclareOption{mytheorems}{\@mytheoremstrue} %_%_%_%_% remove theorem defs from class????
+%
+\newif\if@citeref
+\@citereftrue
+
+
+\DeclareOption{nociteref}{\@citereffalse}
+%
+\ExecuteOptions{plain-opener,letterpaper,10pt,twoside,onecolumn,final,openright}
+\ProcessOptions
+\input{newsiambk1\@ptsize.clo}
+\setlength\lineskip{1\p@}
+\setlength\normallineskip{1\p@}
+\renewcommand\baselinestretch{}
+\setlength\parskip{0\p@ \@plus \p@}
+\@lowpenalty   51
+\@medpenalty  151
+\@highpenalty 301
+\setcounter{topnumber}{2}
+\renewcommand\topfraction{.9}
+\setcounter{bottomnumber}{1}
+\renewcommand\bottomfraction{.1}
+\setcounter{totalnumber}{3}
+\renewcommand\textfraction{.1}
+\renewcommand\floatpagefraction{.91}
+\setcounter{dbltopnumber}{2}
+\renewcommand\dbltopfraction{.7}
+\renewcommand\dblfloatpagefraction{.5}
+\if@twoside
+  \def\ps@headings{%
+      \let\@oddfoot\@empty\let\@evenfoot\@empty
+      \def\@evenhead{{\rule[-5pt]{\textwidth}{1pt}}\hspace*{-\textwidth}\sffamily\thepage\hfil\leftmark}%
+      \def\@oddhead{{\rule[-5pt]{\textwidth}{1pt}}\hspace*{-\textwidth}\sffamily{\rightmark}\hfil\thepage}%
+      \let\@mkboth\markboth
+    \def\chaptermark##1{%
+      \markboth {{%%%%%was \MakeUppercase
+        \ifnum \c@secnumdepth >\m@ne
+          \if@mainmatter
+            \@chapapp\ \thechapter. \ %
+          \fi
+        \fi
+        ##1}}{}}%
+    \def\sectionmark##1{%
+      \markright {{%%%%%was \MakeUppercase
+        \ifnum \c@secnumdepth >\z@
+          \thesection. \ %
+        \fi
+        ##1}}}}
+\else
+  \def\ps@headings{%
+    \let\@oddfoot\@empty
+    \def\@oddhead{{\sffamily\rightmark}\hfil\thepage}%
+    \let\@mkboth\markboth
+    \def\chaptermark##1{%
+      \markright {\MakeUppercase{%
+        \ifnum \c@secnumdepth >\m@ne
+          \if@mainmatter
+            \@chapapp\ \thechapter. \ %
+          \fi
+        \fi
+        ##1}}}}
+\fi
+\def\ps@myheadings{%
+    \let\@oddfoot\@empty\let\@evenfoot\@empty
+    \def\@evenhead{\sffamily\thepage\hfil\sffamily\leftmark}%
+    \def\@oddhead{{\sffamily\rightmark}\hfil\sffamily\thepage}%
+    \let\@mkboth\@gobbletwo
+    \let\chaptermark\@gobble
+    \let\sectionmark\@gobble
+    }
+\def\ps@plain{\let\@mkboth\@gobbletwo
+     \let\@oddhead\@empty\def\@oddfoot{\reset@font\hfil\sffamily\thepage
+     \hfil}\let\@evenhead\@empty\let\@evenfoot\@oddfoot}
+  \if@titlepage
+  \newcommand\maketitle{\begin{titlepage}%
+  \let\footnotesize\small
+  \let\footnoterule\relax
+  \let \footnote \thanks
+  \null\vfil
+  \vskip 60\p@
+  \begin{center}%
+    {\LARGE \@title \par}%
+    \vskip 3em%
+    {\large
+     \lineskip .75em%
+      \begin{tabular}[t]{c}%
+        \@author
+      \end{tabular}\par}%
+      \vskip 1.5em%
+    {\large \@date \par}%       % Set date in \large size.
+  \end{center}\par
+  \@thanks
+  \vfil\null
+  \end{titlepage}%
+  \setcounter{footnote}{0}%
+  \global\let\thanks\relax
+  \global\let\maketitle\relax
+  \global\let\@thanks\@empty
+  \global\let\@author\@empty
+  \global\let\@date\@empty
+  \global\let\@title\@empty
+  \global\let\title\relax
+  \global\let\author\relax
+  \global\let\date\relax
+  \global\let\and\relax
+}
+\else
+\newcommand\maketitle{\par
+  \begingroup
+    \renewcommand\thefootnote{\@fnsymbol\c@footnote}%
+    \def\@makefnmark{\rlap{\@textsuperscript{\normalfont\@thefnmark}}}%
+    \long\def\@makefntext##1{\parindent 1em\noindent
+            \hb@xt@1.8em{%
+                \hss\@textsuperscript{\normalfont\@thefnmark}}##1}%
+    \if@twocolumn
+      \ifnum \col@number=\@ne
+        \@maketitle
+      \else
+        \twocolumn[\@maketitle]%
+      \fi
+    \else
+      \newpage
+      \global\@topnum\z@   % Prevents figures from going at top of page.
+      \@maketitle
+    \fi
+    \thispagestyle{plain}\@thanks
+  \endgroup
+  \setcounter{footnote}{0}%
+  \global\let\thanks\relax
+  \global\let\maketitle\relax
+  \global\let\@maketitle\relax
+  \global\let\@thanks\@empty
+  \global\let\@author\@empty
+  \global\let\@date\@empty
+  \global\let\@title\@empty
+  \global\let\title\relax
+  \global\let\author\relax
+  \global\let\date\relax
+  \global\let\and\relax
+}
+\def\@maketitle{%
+  \newpage
+  \null
+  \vskip 2em%
+  \begin{center}%
+  \let \footnote \thanks
+    {\LARGE \@title \par}%
+    \vskip 1.5em%
+    {\large
+      \lineskip .5em%
+      \begin{tabular}[t]{c}%
+        \@author
+      \end{tabular}\par}%
+    \vskip 1em%
+    {\large \@date}%
+  \end{center}%
+  \par
+  \vskip 1.5em}
+\fi
+\newcommand*\chaptermark[1]{}
+\setcounter{secnumdepth}{2}
+\newcounter {part}
+\newcounter {chapter}
+\newcounter {section}[chapter]
+\newcounter {subsection}[section]
+\newcounter {subsubsection}[subsection]
+\newcounter {paragraph}[subsubsection]
+\newcounter {subparagraph}[paragraph]
+\renewcommand \thepart {\@Roman\c@part}
+\renewcommand \thechapter {\@arabic\c@chapter}
+\renewcommand \thesection {\thechapter.\@arabic\c@section}
+\renewcommand\thesubsection   {\thesection.\@arabic\c@subsection}
+\renewcommand\thesubsubsection{\thesubsection .\@arabic\c@subsubsection}
+\renewcommand\theparagraph    {\thesubsubsection.\@arabic\c@paragraph}
+\renewcommand\thesubparagraph {\theparagraph.\@arabic\c@subparagraph}
+\newcommand\@chapapp{\chaptername}
+\newcommand\frontmatter{%
+    \cleardoublepage
+  \@mainmatterfalse
+  \pagenumbering{roman}}
+\newcommand\mainmatter{%
+    \cleardoublepage
+  \@mainmattertrue
+  \pagenumbering{arabic}}
+\newcommand\backmatter{%
+  \if@openright
+    \cleardoublepage
+  \else
+    \clearpage
+  \fi
+  \@mainmatterfalse}
+\newcommand\part{%
+  \if@openright
+    \cleardoublepage
+  \else
+    \clearpage
+  \fi
+  \thispagestyle{plain}%
+  \if@twocolumn
+    \onecolumn
+    \@tempswatrue
+  \else
+    \@tempswafalse
+  \fi
+  \null%%%%%\vfil
+\vspace*{72pt}
+  \secdef\@part\@spart}
+
+
+
+\def\@spart#1{%
+    {\centering
+     \interlinepenalty \@M
+     \normalfont
+     \sffamily\Huge \bfseries #1\par}%
+    \@endpart}
+\def\@endpart{\vfil\newpage
+              \if@twoside
+                \null
+                \thispagestyle{empty}%
+                \newpage
+              \fi
+              \if@tempswa
+                \twocolumn
+              \fi}
+\newcommand\chapter{\if@openright\cleardoublepage\else\clearpage\fi
+                    \thispagestyle{plain}%
+                    \global\@topnum\z@
+                    \@afterindentfalse
+                    \secdef\@chapter\@schapter}
+%_%_%_%_%
+%_%_%_%_% add third parameter to \chapter to include background graphic
+%_%_%_%_%
+\def\@chapter[#1]#2{\ifnum \c@secnumdepth >\m@ne
+                       \if@mainmatter
+                         \refstepcounter{chapter}%
+                         \typeout{\@chapapp\space\thechapter.}%
+                         \addcontentsline{toc}{chapter}%
+                                   {\protect\numberline{\thechapter}#1}%
+                       \else
+                         \addcontentsline{toc}{chapter}{#1}%
+                       \fi
+                    \else
+                      \addcontentsline{toc}{chapter}{#1}%
+                    \fi
+                    \chaptermark{#1}%
+                    \addtocontents{lof}{\protect\addvspace{10\p@}}%
+                    \addtocontents{lot}{\protect\addvspace{10\p@}}%
+                    \if@twocolumn
+                      \@topnewpage[\@makechapterhead{#2}]%
+                    \else
+                      \@makechapterhead{#2}%
+                      \@afterheading
+                    \fi}
+%_%_%_%_%
+%_%_%_%_% new definition for chapter-page quote
+%_%_%_%_% optional argument moves environment right, in order to center
+\newenvironment{chapterquote}[1][0pt]{\normalsize\normalfont\itshape%
+\advance\leftskip#1}{\par}
+\def\@schapter#1{\if@twocolumn
+                   \@topnewpage[\@makeschapterhead{#1}]%
+                 \else
+                   \@makeschapterhead{#1}%
+                   \@afterheading
+                 \fi}
+\def\@makeschapterhead#1{%
+  \vspace*{50\p@}%
+  {\parindent \z@ \raggedright
+    \normalfont
+    \interlinepenalty\@M\centering
+    \Huge \sffamily\bfseries  #1\par\nobreak
+    \vskip 40\p@
+  }}
+\newcommand\section{\@startsection {section}{1}{\z@}%
+                                   {-3.5ex \@plus -1ex \@minus -.2ex}%
+                                   {1.5ex \@plus.0ex}%
+                                   {\raggedright\normalfont\fontsize{14}{16pt}\selectfont\sffamily\bfseries}}
+\newcommand\subsection{\@startsection{subsection}{2}{\z@}%
+                                     {-3.25ex\@plus -1ex \@minus -.2ex}%
+                                     {1.5ex \@plus .2ex}%
+                                     {\raggedright\normalfont\large\sffamily\bfseries}}
+\newcommand\subsubsection{\@startsection{subsubsection}{3}{\z@}%
+                                     {-3.25ex\@plus -1ex \@minus -.2ex}%
+                                     {1.5ex \@plus .2ex}%
+                                     {\normalfont\normalsize\sffamily\bfseries}}
+\newcommand\paragraph{\@startsection{paragraph}{4}{\z@}%
+                                    {3.25ex \@plus1ex \@minus.2ex}%
+                                    {-1em}%
+                                    {\normalfont\normalsize\sffamily\bfseries}}
+\newcommand\subparagraph{\@startsection{subparagraph}{5}{\parindent}%
+                                       {3.25ex \@plus1ex \@minus .2ex}%
+                                       {-1em}%
+                                      {\normalfont\normalsize\sffamily\bfseries}}
+\if@twocolumn
+  \setlength\leftmargini  {2em}
+\else
+  \setlength\leftmargini  {2.5em}
+\fi
+\leftmargin  \leftmargini
+\setlength\leftmarginii  {2.2em}
+\setlength\leftmarginiii {1.87em}
+\setlength\leftmarginiv  {1.7em}
+\if@twocolumn
+  \setlength\leftmarginv  {.5em}
+  \setlength\leftmarginvi {.5em}
+\else
+  \setlength\leftmarginv  {1em}
+  \setlength\leftmarginvi {1em}
+\fi
+\setlength  \labelsep  {.5em}
+\setlength  \labelwidth{\leftmargini}
+\addtolength\labelwidth{-\labelsep}
+\@beginparpenalty -\@lowpenalty
+\@endparpenalty   -\@lowpenalty
+\@itempenalty     -\@lowpenalty
+\renewcommand\theenumi{\@arabic\c@enumi}
+\renewcommand\theenumii{\@alph\c@enumii}
+\renewcommand\theenumiii{\@roman\c@enumiii}
+\renewcommand\theenumiv{\@Alph\c@enumiv}
+\newcommand\labelenumi{\theenumi.}
+\newcommand\labelenumii{(\theenumii)}
+\newcommand\labelenumiii{\theenumiii.}
+\newcommand\labelenumiv{\theenumiv.}
+\renewcommand\p@enumii{\theenumi}
+\renewcommand\p@enumiii{\theenumi(\theenumii)}
+\renewcommand\p@enumiv{\p@enumiii\theenumiii}
+\newcommand\labelitemi{\textbullet}
+\newcommand\labelitemii{\normalfont\bfseries \textendash}
+\newcommand\labelitemiii{\textasteriskcentered}
+\newcommand\labelitemiv{\textperiodcentered}
+\newenvironment{description}
+               {\list{}{\labelwidth\z@ \itemindent-\leftmargin
+                        \let\makelabel\descriptionlabel}}
+               {\endlist}
+\newcommand*\descriptionlabel[1]{\hspace\labelsep
+                                \normalfont\bfseries #1}
+\newenvironment{verse}
+               {\let\\\@centercr
+                \list{}{\itemsep      \z@
+                        \itemindent   -1.5em%
+                        \listparindent\itemindent
+                        \rightmargin  \leftmargin
+                        \advance\leftmargin 1.5em}%
+                \item\relax}
+               {\endlist}
+\newenvironment{quotation}
+               {\list{}{\listparindent 1.5em%
+                        \itemindent    \listparindent
+                        \rightmargin   \leftmargin
+                        \parsep        \z@ \@plus\p@}%
+                \item\relax}
+               {\endlist}
+\newenvironment{quote}
+               {\list{}{\rightmargin\leftmargin}%
+                \item\relax}
+               {\endlist}
+\if@compatibility
+\newenvironment{titlepage}
+    {%
+      \cleardoublepage
+      \if@twocolumn
+        \@restonecoltrue\onecolumn
+      \else
+        \@restonecolfalse\newpage
+      \fi
+      \thispagestyle{empty}%
+      \setcounter{page}\z@
+    }%
+    {\if@restonecol\twocolumn \else \newpage \fi
+    }
+\else
+\newenvironment{titlepage}
+    {%
+      \cleardoublepage
+      \if@twocolumn
+        \@restonecoltrue\onecolumn
+      \else
+        \@restonecolfalse\newpage
+      \fi
+      \thispagestyle{empty}%
+      \setcounter{page}\@ne
+    }%
+    {\if@restonecol\twocolumn \else \newpage \fi
+     \if@twoside\else
+        \setcounter{page}\@ne
+     \fi
+    }
+\fi
+\newcommand\appendix{\par
+  \setcounter{chapter}{0}%
+  \setcounter{section}{0}%
+  \renewcommand\@chapapp{\appendixname}%
+  \renewcommand\thechapter{\@Alph\c@chapter}}
+\setlength\arraycolsep{5\p@}
+\setlength\tabcolsep{6\p@}
+\setlength\arrayrulewidth{.4\p@}
+\setlength\doublerulesep{2\p@}
+\setlength\tabbingsep{\labelsep}
+\skip\@mpfootins = \skip\footins
+\setlength\fboxsep{3\p@}
+\setlength\fboxrule{.4\p@}
+\@addtoreset {equation}{chapter}
+\renewcommand\theequation
+  {\ifnum \c@chapter>\z@ \thechapter.\fi \@arabic\c@equation}
+\newcounter{figure}[chapter]
+\renewcommand \thefigure
+     {\ifnum \c@chapter>\z@ \thechapter.\fi \@arabic\c@figure}
+\def\fps@figure{tbp}
+\def\ftype@figure{1}
+\def\ext@figure{lof}
+\def\fnum@figure{\figurename~\thefigure}
+\newenvironment{figure}
+               {\@float{figure}}
+               {\end@float}
+\newenvironment{figure*}
+               {\@dblfloat{figure}}
+               {\end@dblfloat}
+\newcounter{table}[chapter]
+\renewcommand \thetable
+     {\ifnum \c@chapter>\z@ \thechapter.\fi \@arabic\c@table}
+\def\fps@table{tbp}
+\def\ftype@table{2}
+\def\ext@table{lot}
+\def\fnum@table{\tablename~\thetable}
+\newenvironment{table}
+               {\@float{table}}
+               {\end@float}
+\newenvironment{table*}
+               {\@dblfloat{table}}
+               {\end@dblfloat}
+\newlength\abovecaptionskip
+\newlength\belowcaptionskip
+\setlength\abovecaptionskip{10\p@}
+\setlength\belowcaptionskip{0\p@}
+\def\xtable{table}
+\long\def\@makecaption#1#2{%
+  \vskip\abovecaptionskip
+  \sbox\@tempboxa{\textbf{#1.} \itshape#2}%
+  \ifdim \wd\@tempboxa >\hsize
+    \hspace*{3pc}{\textbf{#1.} }\itshape#2\par
+  \else
+    \global \@minipagefalse
+    \hb@xt@\hsize{\hfil\box\@tempboxa\hfil}%
+  \fi
+\ifx\@captype\xtable
+\vskip6pt
+\else
+\fi
+  \vskip\belowcaptionskip}
+\DeclareOldFontCommand{\rm}{\normalfont\rmfamily}{\mathrm}
+\DeclareOldFontCommand{\sf}{\normalfont\sffamily}{\mathsf}
+\DeclareOldFontCommand{\tt}{\normalfont\ttfamily}{\mathtt}
+\DeclareOldFontCommand{\bf}{\normalfont\bfseries}{\mathbf}
+\DeclareOldFontCommand{\it}{\normalfont\itshape}{\mathit}
+\DeclareOldFontCommand{\sl}{\normalfont\slshape}{\@nomath\sl}
+\DeclareOldFontCommand{\sc}{\normalfont\scshape}{\@nomath\sc}
+\DeclareRobustCommand*\cal{\@fontswitch\relax\mathcal}
+\DeclareRobustCommand*\mit{\@fontswitch\relax\mathnormal}
+\newcommand\@pnumwidth{15pt}
+\newcommand\@tocrmarg{2.55em}
+\newcommand\@dotsep{4.5}
+\setcounter{tocdepth}{2}
+\newcommand\tableofcontents{%
+    \if@twocolumn
+      \@restonecoltrue\onecolumn
+    \else
+      \@restonecolfalse
+    \fi
+    \chapter*{\contentsname
+        \@mkboth{%
+           \contentsname}{\contentsname}}%
+    \@starttoc{toc}%
+    \if@restonecol\twocolumn\fi
+    }
+\newcommand*\l@part[2]{%
+  \ifnum \c@tocdepth >-2\relax
+    \addpenalty{-\@highpenalty}%
+    \addvspace{2.25em \@plus\p@}%
+    \begingroup
+      \parindent \z@ \rightskip \@pnumwidth
+      \parfillskip -\@pnumwidth
+      {\leavevmode
+       \normalsize \bfseries #1\hfil \hb@xt@\@pnumwidth{\hss #2}}\par
+       \nobreak
+         \global\@nobreaktrue
+         \everypar{\global\@nobreakfalse\everypar{}}%
+    \endgroup
+  \fi}
+\newcommand*\l@chapter[2]{%
+  \ifnum \c@tocdepth >\m@ne
+    \addpenalty{-\@highpenalty}%
+    \vskip 1.0em \@plus\p@
+    \setlength\@tempdima{2.5em}%was 1.5em
+    \begingroup
+      \parindent \z@ \rightskip \@pnumwidth
+      \parfillskip -\@pnumwidth
+      \leavevmode \bfseries
+      \advance\leftskip\@tempdima
+      \hskip -\leftskip
+      #1\nobreak\hfil \nobreak\hb@xt@\@pnumwidth{\hss #2}\par
+      \penalty\@highpenalty
+    \endgroup
+  \fi}
+
+
+\newcommand*\l@section{\@dottedtocline{1}{2.5em}{3.3em}}
+\newcommand*\l@subsection{\@dottedtocline{2}{5.8em}{5.2em}}
+\newcommand*\l@subsubsection{\@dottedtocline{3}{7.0em}{4.1em}}
+\newcommand*\l@paragraph{\@dottedtocline{4}{10em}{5em}}
+\newcommand*\l@subparagraph{\@dottedtocline{5}{12em}{6em}}
+\newcommand\listoffigures{%
+    \if@twocolumn
+      \@restonecoltrue\onecolumn
+    \else
+      \@restonecolfalse
+    \fi
+    \chapter*{\listfigurename
+      \@mkboth{\listfigurename}%
+              {\listfigurename}}%
+    \@starttoc{lof}%
+    \if@restonecol\twocolumn\fi
+    }
+%_%_%_%_%
+%_%_%_%_%make list of algorithms
+%_%_%_%_%
+\newcommand*\l@algorithm{\@dottedtocline{1}{0pt}{84pt}}
+\newcommand\listofalgorithms{%
+    \if@twocolumn
+      \@restonecoltrue\onecolumn
+    \else
+      \@restonecolfalse
+    \fi
+    \chapter*{List of Algorithms
+      \@mkboth{{List of Algorithms}}%
+              {{List of Algorithms}}}%
+    \@starttoc{loa}%
+    \if@restonecol\twocolumn\fi
+    }
+
+\newcounter{algorithm}[chapter]
+\renewcommand{\thealgorithm}{\arabic{chapter}.\arabic{algorithm}}
+\newenvironment{algorithm}[1][\relax]{\refstepcounter{algorithm}%
+\addcontentsline{loa}{algorithm}%
+    {\protect\numberline{Algorithm~\thealgorithm}{\ignorespaces#1}}%
+\par\vspace{1\baselineskip}%
+\expandafter\ifx#1\relax
+\parindent0pt {\scshape\bfseries Algorithm~\thealgorithm.}\\%%%
+\else
+\parindent0pt {\scshape\bfseries Algorithm~\thealgorithm.}\enspace{\bfseries#1.}\\%%%
+\fi}
+{\vspace{1\baselineskip}\par}
+%_%_%_%_%
+%_%_%_%_%
+%_%_%_%_%
+%%%\newcommand*\l@figure{\@dottedtocline{1}{1.5em}{2.3em}}
+\newcommand*\l@figure{\@dottedtocline{1}{1.5em}{3.3em}}
+\newcommand\listoftables{%
+    \if@twocolumn
+      \@restonecoltrue\onecolumn
+    \else
+      \@restonecolfalse
+    \fi
+    \chapter*{\listtablename
+      \@mkboth{%
+          \listtablename}{\listtablename}}%
+    \@starttoc{lot}%
+    \if@restonecol\twocolumn\fi
+    }
+\let\l@table\l@figure
+\newdimen\bibindent
+\setlength\bibindent{1.5em}
+\newenvironment{thebibliography}[1]
+     {\chapter*{\bibname
+        \@mkboth{\bibname}{\bibname}}%
+\addcontentsline{toc}{chapter}{\bibname}%
+      \list{\@biblabel{\@arabic\c@enumiv}}%
+           {\settowidth\labelwidth{\@biblabel{#1}}%
+            \leftmargin\labelwidth
+            \advance\leftmargin\labelsep
+            \@openbib@code
+            \usecounter{enumiv}%
+            \let\p@enumiv\@empty
+            \renewcommand\theenumiv{\@arabic\c@enumiv}}%
+      \sloppy
+      \clubpenalty4000
+      \@clubpenalty \clubpenalty
+      \widowpenalty4000%
+      \sfcode`\.\@m}
+     {\def\@noitemerr
+       {\@latex@warning{Empty `thebibliography' environment}}%
+      \endlist}
+\newcommand\newblock{\hskip .11em\@plus.33em\@minus.07em}
+\let\@openbib@code\@empty
+\newenvironment{theindex}
+               {\if@twocolumn
+                  \@restonecolfalse
+                \else
+                  \@restonecoltrue
+                \fi
+                \columnseprule \z@
+                \columnsep 35\p@
+                \twocolumn[\@makeschapterhead{\indexname}]%
+		\addcontentsline{toc}{chapter}{\indexname}%
+                \@mkboth{\indexname}%
+                        {\indexname}%
+                \thispagestyle{plain}\parindent\z@
+                \parskip\z@ \@plus .3\p@\relax
+                \let\item\@idxitem}
+               {\if@restonecol\onecolumn\else\clearpage\fi}
+\newcommand\@idxitem{\par\hangindent 40\p@}
+\newcommand\subitem{\@idxitem \hspace*{20\p@}}
+\newcommand\subsubitem{\@idxitem \hspace*{30\p@}}
+\newcommand\indexspace{\par \vskip 10\p@ \@plus5\p@ \@minus3\p@\relax}
+\renewcommand\footnoterule{%
+  \kern-3\p@
+  \hrule\@width6pc
+  \kern2.6\p@}
+%%%% 05/01/02 deleted to change numbering \@addtoreset{footnote}{chapter}
+\newcommand\@makefntext[1]{%
+    \parindent 1em%
+    \noindent\hb@xt@1.8em{\hss\@makefnmark}#1}
+\newcommand\contentsname{Contents}
+\newcommand\listfigurename{List of Figures}
+\newcommand\listtablename{List of Tables}
+\newcommand\bibname{Bibliography}
+\newcommand\indexname{Index}
+\newcommand\figurename{Figure}
+\newcommand\tablename{Table}
+\newcommand\partname{Part}
+\newcommand\chaptername{Chapter}
+\newcommand\appendixname{Appendix}
+\def\today{\ifcase\month\or
+  January\or February\or March\or April\or May\or June\or
+  July\or August\or September\or October\or November\or December\fi
+  \space\number\day, \number\year}
+\setlength\columnsep{10\p@}
+\setlength\columnseprule{0\p@}
+\pagestyle{headings}
+\pagenumbering{arabic}
+\if@twoside
+\else
+  \raggedbottom
+\fi
+\if@twocolumn
+  \twocolumn
+  \sloppy
+  \flushbottom
+\else
+  \onecolumn
+\fi
+
+
+%_%_%_%_%
+%_%_%_%_% borrowed from siamltex.cls...
+%_%_%_%_%
+
+\def\@begintheorem#1#2{\vskip-\lastskip\par\vskip12pt\par%
+\bgroup\noindent{\bfseries #1\ #2. }\it\ignorespaces}
+%
+\def\@opargbegintheorem#1#2#3{\vskip-\lastskip\par\vskip12pt\par\bgroup%
+   \noindent{\bfseries #1\ #2\ ({\upshape #3}). }\it\ignorespaces}
+%
+\def\@endtheorem{\egroup\vskip12pt}
+%
+
+
+%%% create theorems, etc. with upright font, no italic
+\def\newtheoremup#1{%
+  \@ifnextchar[{\@othmup{#1}}{\@nthmup{#1}}}
+\def\@nthmup#1#2{%
+  \@ifnextchar[{\@xnthmup{#1}{#2}}{\@ynthmup{#1}{#2}}}
+\def\@xnthmup#1#2[#3]{%
+  \expandafter\@ifdefinable\csname #1\endcsname
+    {\@definecounter{#1}\@newctr{#1}[#3]%
+     \expandafter\xdef\csname the#1\endcsname{%
+       \expandafter\noexpand\csname the#3\endcsname \@thmcountersep
+          \@thmcounterup{#1}}%
+     \global\@namedef{#1}{\@thmup{#1}{#2}}%
+     \global\@namedef{end#1}{\@endtheoremup}}}
+\def\@ynthmup#1#2{%
+  \expandafter\@ifdefinable\csname #1\endcsname
+    {\@definecounter{#1}%
+     \expandafter\xdef\csname the#1\endcsname{\@thmcounterup{#1}}%
+     \global\@namedef{#1}{\@thmup{#1}{#2}}%
+     \global\@namedef{end#1}{\@endtheoremup}}}
+\def\@othmup#1[#2]#3{%
+  \@ifundefined{c@#2}{\@nocounterr{#2}}%
+    {\expandafter\@ifdefinable\csname #1\endcsname
+    {\global\@namedef{the#1}{\@nameuse{the#2}}%
+  \global\@namedef{#1}{\@thmup{#2}{#3}}%
+  \global\@namedef{end#1}{\@endtheoremup}}}}
+\def\@thmup#1#2{%
+  \refstepcounter{#1}%
+  \@ifnextchar[{\@ythmup{#1}{#2}}{\@xthmup{#1}{#2}}}
+\def\@xthmup#1#2{%
+  \@begintheoremup{#2}{\csname the#1\endcsname}\ignorespaces}
+\def\@ythmup#1#2[#3]{%
+  \@opargbegintheoremup{#2}{\csname the#1\endcsname}{#3}\ignorespaces}
+\def\@thmcounterup#1{\noexpand\arabic{#1}}
+\def\@thmcountersep{.}
+\def\@begintheoremup#1#2{\trivlist
+   \item[\hskip \labelsep{\bfseries #1\ #2}]\upshape}
+\def\@opargbegintheoremup#1#2#3{\trivlist
+      \item[\hskip \labelsep{\bfseries #1\ #2\ (#3)}]\upshape}
+\def\@endtheoremup{\endtrivlist}
+
+
+\newlength{\proofboxwd}
+\setlength{\proofboxwd}{1pt}
+
+\def\proofbox{\hspace{12\proofboxwd}\vbox{\hrule height0.6\proofboxwd\hbox{%
+   \vrule height1.3ex width0.6\proofboxwd\hskip0.8ex
+   \vrule width0.6\proofboxwd}\hrule height0.6\proofboxwd
+  }}
+
+\def\examplebox{\hspace{12\proofboxwd}\rule{5.36pt}{7.91pt}}
+
+
+\def\tempproofbox{\hspace{12\proofboxwd}\vbox{\hrule height0.6\proofboxwd\hbox{%
+   \vrule height1.3ex width0.6\proofboxwd\hskip0.8ex
+   \vrule width0.6\proofboxwd}\hrule height0.6pt
+  }}
+
+
+\def\myproofbox{\tempproofbox\global\setlength{\proofboxwd}{0pt}}
+
+\newenvironment{proof}{%
+\vskip-\lastskip\par
+\vskip12pt\par\noindent{\bfseries\itshape Proof.} \ignorespaces}%
+{\proofbox\vspace{1\baselineskip}\global\setlength{\proofboxwd}{1pt}}
+
+
+\if@mytheorems
+\else
+\if@onethmnum
+  \newtheorem{theorem}{Theorem}
+  \newtheorem{lemma}[theorem]{Lemma}
+  \newtheorem{corollary}[theorem]{Corollary}
+  \newtheorem{proposition}[theorem]{Proposition}
+  \newtheorem{definition}[theorem]{Definition}
+  \newtheoremup{example}[theorem]{Example}
+\else
+  \newtheorem{theorem}{Theorem}[chapter]
+  \newtheorem{lemma}[theorem]{Lemma}
+  \newtheorem{corollary}[theorem]{Corollary}
+  \newtheorem{proposition}[theorem]{Proposition}
+  \newtheorem{definition}[theorem]{Definition}
+  \newtheoremup{example}[theorem]{Example}
+\fi
+\let\tempendexample\@endtheoremup
+\def\endexample{\examplebox\tempendexample}
+\fi
+
+
+\newcounter{rmnum}
+\newenvironment{romannum}
+               {\begin{list}{{\hfill\upshape (\roman{rmnum})}}{\usecounter{rmnum}
+                \setlength{\leftmargin}{24pt}\labelwidth24pt\labelsep.5em%
+		\itemsep2pt\parsep0pt
+                \setlength{\itemindent}{0pt}}}{\end{list}}
+\newcounter{muni}
+\newenvironment{remunerate}
+               {\begin{list}{{\hfill\upshape \arabic{muni}.}}{\usecounter{muni}
+                \setlength{\leftmargin}{24pt}\labelwidth24pt\labelsep.5em%
+		\itemsep2pt\parsep0pt
+                \setlength{\itemindent}{0pt}}}{\end{list}}
+
+\newenvironment{bulletlist}
+{\begin{list}{{\hfill\raisebox{1.12pt}{$\bullet$}}}{%
+                \setlength{\leftmargin}{24pt}\labelwidth24pt\labelsep.5em%
+		\itemsep2pt\parsep0pt
+                \setlength{\itemindent}{0pt}}}{\end{list}}
+
+
+\newenvironment{alphlist}
+               {\begin{list}{{\hfill\upshape (\alph{muni})}}{\usecounter{muni}
+                \setlength{\leftmargin}{24pt}\labelwidth24pt\labelsep.5em%
+		\itemsep2pt\parsep0pt
+                \setlength{\itemindent}{0pt}}}{\end{list}}
+
+
+\newcommand\sameauthor{\leavevmode\vrule height 2pt depth -1.6pt width 23pt}
+
+
+%_%_%_%_% fix eqnarray spacing
+\def\@tempb{%
+   \stepcounter{equation}%
+   \def\@currentlabel{\p@equation\theequation}%
+   \global\@eqnswtrue
+   \m@th
+   \global\@eqcnt\z@
+   \tabskip\@centering
+   \let\\\@eqncr
+   $$\everycr{}\halign to\displaywidth\bgroup
+       \hskip\@centering$\displaystyle\tabskip\z@skip{##}$\@eqnsel
+      &\global\@eqcnt\@ne\hskip \tw@\arraycolsep \hfil${##}$\hfil
+      &\global\@eqcnt\tw@ \hskip \tw@\arraycolsep
+         $\displaystyle{##}$\hfil\tabskip\@centering
+      &\global\@eqcnt\thr@@ \hb@xt@\z@\bgroup\hss##\egroup
+         \tabskip\z@skip
+      \cr
+}
+\ifx\eqnarray\@tempb    % Try the default eqnarray environment
+  \def\eqnarray{%
+   \stepcounter{equation}%
+   \def\@currentlabel{\p@equation\theequation}%
+   \global\@eqnswtrue
+   \m@th
+   \global\@eqcnt\z@
+   \tabskip\@centering
+   \let\\\@eqncr
+   $$\everycr{}\halign to\displaywidth\bgroup
+       \hskip\@centering$\displaystyle\tabskip\z@skip{##}$\@eqnsel
+      &\global\@eqcnt\@ne \hfil$\displaystyle{{}##{}}$\hfil
+      &\global\@eqcnt\tw@ $\displaystyle{##}$\hfil\tabskip\@centering
+      &\global\@eqcnt\thr@@ \hb@xt@\z@\bgroup\hss##\egroup
+         \tabskip\z@skip
+      \cr
+}
+\else    \typeout{Warning: Unable to fix unknown version of \string\eqnarray.}
+\fi
+ 
+\def\@tempb{}
+
+
+%_%_%_%_%
+%_%_%_%_% for crops and other stuff...
+%_%_%_%_%
+\setlength{\paperheight}{10in}
+\setlength{\paperwidth}{7in}
+
+\setlength{\oddsidemargin}{.75in}
+\setlength{\evensidemargin}{.766in}
+
+%_%_%_%_%
+%_%_%_%_% Problems/exercises
+%_%_%_%_%
+\newcounter{prob}
+\newenvironment{problems}
+               {%
+\section*{\rule[6pt]{\textwidth}{1pt}\newline\nobreak Problems}%
+\addcontentsline{toc}{section}{Problems}%
+\markright{Problems}
+\begin{list}{{\hfill\upshape \arabic{prob}.}}{\usecounter{prob}
+                \setlength{\leftmargin}{24pt}\labelwidth24pt\labelsep.5em%
+		\itemsep2pt\parsep0pt
+                \setlength{\itemindent}{0pt}}}{\end{list}}
+
+\newenvironment{exercises}
+               {%
+\section*{\rule[6pt]{\textwidth}{1pt}\newline\nobreak Exercises}%
+\addcontentsline{toc}{section}{Exercises}%
+\markright{Exercises}
+\begin{list}{{\hfill\upshape \arabic{chapter}.\arabic{prob}.}}{\usecounter{prob}
+                \setlength{\leftmargin}{28pt}\labelwidth28pt\labelsep.5em%
+		\itemsep2pt\parsep0pt
+                \setlength{\itemindent}{0pt}}}{\end{list}}
+
+%_%_%_%_%
+%_%_%_%_% front matter, etc.
+%_%_%_%_%
+\newenvironment{thepreface}{\if@openright\cleardoublepage\else\clearpage\fi
+\@makeschapterhead{Preface}%
+\addcontentsline{toc}{chapter}{Preface}%
+                \@mkboth{Preface}%
+                        {Preface}%
+                \thispagestyle{plain}}
+               {\clearpage}
+
+%_%_%_%_%
+%_%_%_%_%
+%_%_%_%_%
+
+%_%_%_%_% #1 is the contributor's name, #2 is the affiliation
+\newcommand{\contributor}[2]{\noindent\vtop{\hsize14pc#1\\\itshape#2}\par}
+
+\newenvironment{contributors}{\if@openright\cleardoublepage\else\clearpage\fi
+\@makeschapterhead{List of Contributors}%
+%\addcontentsline{toc}{chapter}{List of Contributors}%
+                \@mkboth{List of Contributors}%
+                        {List of Contributors}%
+                \thispagestyle{plain}\begin{multicols}{2}\parindent0pt%
+\parskip6pt plus2pt minus1pt%
+\widowpenalty10000\clubpenalty10000}
+               {\end{multicols}\clearpage}
+
+\setlength{\parskip}{1\parskip}
+
+
+\parskip1\parskip
+\hfuzz362pt
+
+\if@citeref
+\usepackage{citeref}
+\else
+\fi
+\endinput
+%%
+%% End of file `book.cls'.
+
+
+

--- a/tex_style/siammathtime.sty
+++ b/tex_style/siammathtime.sty
@@ -1,0 +1,342 @@
+%%
+%% This is file `mathtime.sty',
+%% generated with the docstrip utility.
+%%
+%% The original source files were:
+%%
+%% mathtime.dtx  (with options: `package,mathtime')
+%% 
+%% Copyright 1996 1997 Frank Mittelbach and David Carlisle.
+%%
+%% Development of this package was commissioned by Y&Y Inc.
+%% http://www.yandy.com
+\NeedsTeXFormat{LaTeX2e}[1995/01/01]
+\ProvidesPackage{mathtime}
+ [1997/09/01 v1.0d %
+ mathtime
+ font support (FMi/DPC)]
+\newcommand\greekshape{}
+\DeclareOption{slantedgreek}{\renewcommand\greekshape{it}}
+\DeclareOption{uprightgreek}{\renewcommand\greekshape{n}}
+\DeclareOption{nobold}{\let\boldmath=u}
+\DeclareOption{cmbold}{\let\boldmath=c}
+\DeclareOption{mtbold}{\let\boldmath=m}
+\DeclareOption{heavybold}{\let\boldmath=h}
+\newcommand\enablesubscriptcorrection {\catcode`\_=12\relax}
+\newcommand\disablesubscriptcorrection{\catcode`\_=8\relax}
+\DeclareOption{nosubscriptcorrection}{\disablesubscriptcorrection}
+\DeclareOption{subscriptcorrection}  {\enablesubscriptcorrection}
+\DeclareOption{cmcal}    {\let\mathcal=c}
+\DeclareOption{lucidacal}{\let\mathcal=l}
+\DeclareOption{mtplusscr}{\let\mathscr=s}
+\DeclareOption{mtpluscal}{\let\mathcal=s}
+\DeclareOption{lucidascr}{\let\mathscr=l}
+\DeclareOption{noTS1}    {\let\symtextcomp\relax}
+\let\operator@encoding\encodingdefault
+\DeclareOption{OT1}{\def\operator@encoding{OT1}}
+\DeclareOption{T1}{\def\operator@encoding{T1}}
+\DeclareOption{LY1}{\def\operator@encoding{LY1}\ExecuteOptions{noTS1}}
+\DeclareOption{errorshow}{%
+   \def\@font@info#1{%
+         \GenericInfo{(Font)\@spaces\@spaces\@spaces\space\space}%
+                     {LaTeX Font Info: \space\space\space#1}}%
+    \def\@font@warning#1{%
+         \GenericInfo{(Font)\@spaces\@spaces\@spaces\space\space}%
+                        {LaTeX Font Warning: #1}}}
+\DeclareOption{warningshow}{%
+   \def\@font@info#1{%
+         \GenericInfo{(Font)\@spaces\@spaces\@spaces\space\space}%
+                     {LaTeX Font Info: \space\space\space#1}}%
+    \def\@font@warning#1{%
+         \GenericWarning{(Font)\@spaces\@spaces\@spaces\space\space}%
+                        {LaTeX Font Warning: #1}}}
+\DeclareOption{nofontinfo}{%
+   \let\@font@info\@gobble
+   \let\@font@warning\@gobble}
+\ExecuteOptions{%
+  slantedgreek,nobold,nosubscriptcorrection,cmcal,errorshow}
+\ProcessOptions
+\edef\@tempa{\rmdefault}
+\def\@tempb {cmr}
+\ifx\@tempa\@tempb
+  \renewcommand*\sfdefault{poptima}
+  \renewcommand*\rmdefault{ptm}
+  \renewcommand*\ttdefault{pcr}
+  \renewcommand*\bfdefault{b}
+\fi
+\DeclareFontEncoding{MY1}{}{}
+\DeclareFontEncoding{MY2}{}{}
+\DeclareFontEncoding{MY3}{}{}
+\DeclareFontSubstitution{MY1}{mtt}{m}{it}
+\DeclareFontSubstitution{MY2}{mtt}{m}{n}
+\DeclareFontSubstitution{MY3}{mtt}{m}{n}
+\SetSymbolFont{operators}   {normal}{\operator@encoding}{ptm}{m}{n}
+\SetSymbolFont{letters}     {normal}{MY1}{mtt}{m}{it}
+\SetSymbolFont{symbols}     {normal}{MY2}{mtt}{m}{n}
+\SetSymbolFont{largesymbols}{normal}{MY3}{mtt}{m}{n}
+\ifx\boldmath c
+  \SetSymbolFont{operators}   {bold}{\operator@encoding}{cmr}{bx}{n}
+  \SetSymbolFont{letters}     {bold}{OML}{cmm}{b}{it}
+  \SetSymbolFont{symbols}     {bold}{OMS}{cmsy}{b}{n}
+  \SetSymbolFont{largesymbols}{bold}{MY3}{mtt}{m}{n}
+\PackageWarningNoLine{mathtime}
+  {The use of the `cmbold' option will result\MessageBreak
+   in incorrect characters in some circumstances\MessageBreak
+   without any warning as the Math Time fonts and the\MessageBreak
+   Computer Modern fonts have incompatible encodings.\MessageBreak
+   Please use this option with care!\@gobble}
+  \renewcommand\boldmath{\@nomath\boldmath\mathversion{bold}}
+  \let\heavymath\boldmath
+\fi
+\ifx\boldmath u
+  \let\@tempa\version@elt
+    \def\version@elt#1{%
+      \ifx\mv@bold#1\else\noexpand\version@elt\noexpand#1\fi}
+    \edef\version@list{\version@list}
+  \let\version@elt\@tempa
+  \let\mv@bold\@undefined
+  \renewcommand\boldmath{\PackageError{mathtime}%
+               {Bold math is not supported}%
+               {Use cmbold or mtbold options}}
+  \let\heavymath\boldmath
+\fi
+\ifx\boldmath m
+  \SetSymbolFont{operators}{bold}{\operator@encoding}{\rmdefault}{b}{n}
+  \SetSymbolFont{letters}     {bold}{MY1}{mtt}{b}{\greekshape}
+  \SetSymbolFont{symbols}     {bold}{MY2}{mtt}{b}{n}
+  \SetSymbolFont{largesymbols}{bold}{MY3}{mtt}{b}{n}
+  \DeclareMathVersion{heavy}
+  \SetSymbolFont{operators}{heavy}{\operator@encoding}{\rmdefault}{b}{n}
+  \SetSymbolFont{letters}     {heavy}{MY1}{mtt}{ub}{\greekshape}
+  \SetSymbolFont{symbols}     {heavy}{MY2}{mtt}{ub}{n}
+  \SetSymbolFont{largesymbols}{heavy}{MY3}{mtt}{ub}{n}
+  \DeclareMathSymbol{:}{\mathrel}{symbols}{86}
+  \DeclareMathSymbol{!}{\mathclose}{symbols}{87}
+  \DeclareMathSymbol{[}{\mathopen}{symbols}{84}
+  \DeclareMathSymbol{]}{\mathclose}{symbols}{85}
+  \renewcommand\boldmath{\@nomath\boldmath\mathversion{bold}}
+  \newcommand\heavymath{\@nomath\heavymath\mathversion{heavy}}
+\fi
+\ifx\boldmath h
+  \SetSymbolFont{operators}{bold}{\operator@encoding}{\rmdefault}{b}{n}
+  \SetSymbolFont{letters}     {bold}{MY1}{mtt}{ub}{\greekshape}
+  \SetSymbolFont{symbols}     {bold}{MY2}{mtt}{ub}{n}
+  \SetSymbolFont{largesymbols}{bold}{MY3}{mtt}{ub}{n}
+  \DeclareMathSymbol{:}{\mathrel}{symbols}{86}
+  \DeclareMathSymbol{!}{\mathclose}{symbols}{87}
+  \DeclareMathSymbol{[}{\mathopen}{symbols}{84}
+  \DeclareMathSymbol{]}{\mathclose}{symbols}{85}
+  \renewcommand\boldmath{\@nomath\boldmath\mathversion{bold}}
+  \let\heavymath\boldmath
+\fi
+\SetMathAlphabet{\mathrm}{normal}{\encodingdefault}{\rmdefault}{m}{n}
+\SetMathAlphabet{\mathbf}{normal}{\encodingdefault}{\rmdefault}{b}{n}
+\SetMathAlphabet{\mathit}{normal}{\encodingdefault}{\rmdefault}{m}{it}
+\SetMathAlphabet{\mathsf}{normal}{\encodingdefault}{\sfdefault}{m}{n}
+\SetMathAlphabet{\mathtt}{normal}{\encodingdefault}{\ttdefault}{m}{n}
+\ifx\mv@bold\@undefined
+\else
+  \SetMathAlphabet{\mathrm}{bold} {\encodingdefault}{\rmdefault}{b}{n}
+  \SetMathAlphabet{\mathbf}{bold} {\encodingdefault}{\rmdefault}{b}{n}
+  \SetMathAlphabet{\mathit}{bold} {\encodingdefault}{\rmdefault}{b}{it}
+  \SetMathAlphabet{\mathsf}{bold} {\encodingdefault}{\sfdefault}{b}{n}
+  \SetMathAlphabet{\mathtt}{bold} {\encodingdefault}{\ttdefault}{b}{n}
+\fi
+\ifx\mv@heavy\@undefined
+\else
+  \SetMathAlphabet{\mathrm}{heavy}{\encodingdefault}{\rmdefault}{b}{n}
+  \SetMathAlphabet{\mathbf}{heavy}{\encodingdefault}{\rmdefault}{b}{n}
+  \SetMathAlphabet{\mathit}{heavy}{\encodingdefault}{\rmdefault}{b}{it}
+  \SetMathAlphabet{\mathsf}{heavy}{\encodingdefault}{\sfdefault}{b}{n}
+  \SetMathAlphabet{\mathtt}{heavy}{\encodingdefault}{\ttdefault}{b}{n}
+\fi
+\ifx\mathscr s
+  \let\mathscr\relax
+  \DeclareMathAlphabet\mathscr{U}        {mtms}{b}{n}
+  \SetMathAlphabet    \mathscr{normal}{U}{mtms}{m}{n}
+  \DeclareMathAlphabet\mathbscr{U}{mtms}{b}{n}
+\fi
+\ifx\mathscr l
+  \let\mathscr\relax
+  \DeclareMathAlphabet{\mathscr}          {OMS}{lby}{b}{n}
+  \SetMathAlphabet    {\mathscr}{normal}  {OMS}{lby}{m}{n}
+  \DeclareMathAlphabet{\mathbscr}         {OMS}{lby}{b}{n}
+\fi
+\ifx\mathcal l
+  \let\mathcal\relax
+  \DeclareMathAlphabet{\mathcal}          {OMS}{lby}{b}{n}
+  \SetMathAlphabet    {\mathcal}{normal}  {OMS}{lby}{m}{n}
+  \DeclareMathAlphabet{\mathbcal}         {OMS}{lby}{b}{n}
+\fi
+\ifx\mathcal s
+  \let\mathcal\relax
+  \DeclareMathAlphabet\mathcal{U}        {mtms}{b}{n}
+  \SetMathAlphabet    \mathcal{normal}{U}{mtms}{m}{n}
+  \DeclareMathAlphabet\mathbcal{U}{mtms}{b}{n}
+\fi
+\ifx\mathcal c
+  \let\mathcal\relax
+  \DeclareMathAlphabet\mathcal{OMS}        {cmsy}{b}{n}
+  \SetMathAlphabet    \mathcal{normal}{OMS}{cmsy}{m}{n}
+  \DeclareMathAlphabet\mathbcal{OMS}       {cmsy}{b}{n}
+
+\fi
+\DeclareMathSymbol\Gamma  {\mathord}{letters}{48}
+\DeclareMathSymbol\Delta  {\mathord}{letters}{49}
+\DeclareMathSymbol\Theta  {\mathord}{letters}{50}
+\DeclareMathSymbol\Lambda {\mathord}{letters}{51}
+\DeclareMathSymbol\Xi     {\mathord}{letters}{52}
+\DeclareMathSymbol\Pi     {\mathord}{letters}{53}
+\DeclareMathSymbol\Sigma  {\mathord}{letters}{54}
+\DeclareMathSymbol\Upsilon{\mathord}{letters}{55}
+\DeclareMathSymbol\Phi    {\mathord}{letters}{56}
+\DeclareMathSymbol\Psi    {\mathord}{letters}{57}
+\DeclareMathSymbol\Omega  {\mathord}{letters}{127}
+\DeclareMathSymbol\varGamma    {\mathord}{letters}{0}
+\DeclareMathSymbol\varDelta    {\mathord}{letters}{1}
+\DeclareMathSymbol\varTheta    {\mathord}{letters}{2}
+\DeclareMathSymbol\varLambda   {\mathord}{letters}{3}
+\DeclareMathSymbol\varXi       {\mathord}{letters}{4}
+\DeclareMathSymbol\varPi       {\mathord}{letters}{5}
+\DeclareMathSymbol\varSigma    {\mathord}{letters}{6}
+\DeclareMathSymbol\varUpsilon  {\mathord}{letters}{7}
+\DeclareMathSymbol\varPhi      {\mathord}{letters}{8}
+\DeclareMathSymbol\varPsi      {\mathord}{letters}{9}
+\DeclareMathSymbol\varOmega    {\mathord}{letters}{10}
+\DeclareMathSymbol{(}{\mathopen}{letters}{46} % was 028
+\DeclareMathSymbol{)}{\mathclose}{letters}{47} % was 029
+\DeclareMathDelimiter{(}{letters}{46}{largesymbols}{0}
+\DeclareMathDelimiter{)}{letters}{47}{largesymbols}{1}
+\DeclareMathSymbol{\triangleleft}{\mathbin}{symbols}{71}  % was 12F
+\DeclareMathSymbol{\triangleright}{\mathbin}{symbols}{70} % was 12E
+\DeclareMathSymbol{\comp}{\mathbin}{symbols}{66}       % new?
+\DeclareMathSymbol{\setdif}{\mathbin}{symbols}{88}     % new
+\DeclareMathSymbol{\cupprod}{\mathbin}{symbols}{89}    % new
+\DeclareMathSymbol{\capprod}{\mathbin}{symbols}{90}    % new
+\DeclareMathSymbol{+}{\mathbin}{symbols}{67}           % was 02B
+\DeclareMathSymbol{=}{\mathrel}{symbols}{68}           % was 03D
+\let\Relbar\@undefined
+\DeclareMathSymbol{\Relbar}{\mathrel}{symbols}{72}     % was a macro
+\DeclareMathSymbol{;}{\mathpunct}{symbols}{73}         % was 13B
+\DeclareMathSymbol{\varkappa}{\mathord}{letters}{126}   % new (AMS)
+\DeclareMathAccent{\vec}{\mathord}{symbols}{69}
+\DeclareMathAccent{\grave}{\mathord}{symbols}{74}
+\DeclareMathAccent{\acute}{\mathord}{symbols}{75}
+\DeclareMathAccent{\check}{\mathord}{symbols}{76}
+\DeclareMathAccent{\breve}{\mathord}{symbols}{77}
+\DeclareMathAccent{\bar}{\mathord}{symbols}{78}
+\DeclareMathAccent{\hat}{\mathord}{symbols}{79}
+\DeclareMathAccent{\dot}{\mathord}{symbols}{80}
+\DeclareMathAccent{\tilde}{\mathord}{symbols}{81}
+\DeclareMathAccent{\ddot}{\mathord}{symbols}{82}
+\DeclareMathAccent{\widebar}{\mathord}{symbols}{83} % new
+\def\defaultscriptratio{.7}
+\def\defaultscriptscriptratio{.5}
+\newcommand\hb@xmdot{\hbox{$\m@th.$}}
+\def\vdots{\vbox{\baselineskip4\p@ \lineskiplimit\z@
+  \kern6\p@\hb@xmdot\hb@xmdot\hb@xmdot}}
+\def\ddots{\mathinner{\mkern1mu\raise7\p@\vbox{\kern7\p@
+  \hb@xmdot}\mkern2mu
+  \raise4\p@\hb@xmdot\mkern2mu\raise\p@\hb@xmdot\mkern1mu}}
+\def\angle{{\vbox{\ialign{$\m@th\scriptstyle##$\crcr
+      \not\mathrel{\mkern14mu}\crcr
+      \noalign{\nointerlineskip}%
+      \mkern2.5mu%
+      \leaders\hrule\@height.48\p@\hfill\mkern2.5mu\crcr}}}}
+\def\hbar{{%
+ \dimen@.12em%
+ \dimen@ii.1em%
+ \def\@tempa##1##2{{%
+   \lower##1\dimen@\rlap{\kern##1\dimen@ii\the##2\tw@\char78}}}%
+ \mathchoice\@tempa\@ne\textfont
+            \@tempa\@ne\textfont
+            \@tempa\defaultscriptratio\scriptfont
+            \@tempa\defaultscriptscriptratio\scriptscriptfont
+  h}}
+\def\@fnsymbol#1{\ensuremath{\ifcase#1\or *\or \dagger\or \ddagger\or
+   \mathsection\or \mathparagraph\or \|\or **\or \dagger\dagger
+   \or \ddagger\ddagger \else\@ctrerr\fi}}
+\ifx\symtextcomp\relax
+  \def\@tempa{LY1}
+  \ifx\operator@encoding\@tempa
+    \DeclareMathSymbol\dagger {\mathbin}{operators}{134}
+    \DeclareMathSymbol\ddagger{\mathbin}{operators}{135}
+    \DeclareMathSymbol\mathsection{\mathord}{operators}{'247}
+    \DeclareMathSymbol\mathparagraph{\mathord}{operators}{'266}
+    \DeclareMathSymbol\mathsterling{\mathord}{operators}{163}
+    \let\mathunderscore\@undefined
+    \DeclareMathSymbol\mathunderscore{\mathord}{operators}{95}
+  \fi
+  \def\@tempa{T1}
+  \ifx\operator@encoding\@tempa
+    \DeclareMathSymbol\mathsterling{\mathord}{operators}{191}
+    \let\mathunderscore\@undefined
+    \DeclareMathSymbol\mathunderscore{\mathord}{operators}{95}
+  \fi
+\else
+  \DeclareFontEncoding{TS1}{}{}
+  \DeclareSymbolFont{textcomp}{TS1}{ptm}{m}{n}
+  \ifx\mv@bold\@undefined
+  \else
+    \SetSymbolFont    {textcomp}{bold}{TS1}{ptm}{b}{n}
+  \fi
+  \ifx\mv@heavy\@undefined
+  \else
+    \SetSymbolFont    {textcomp}{heavy}{TS1}{ptm}{b}{n}
+  \fi
+  \DeclareMathSymbol\dagger {\mathbin}{textcomp}{'204}
+  \DeclareMathSymbol\ddagger{\mathbin}{textcomp}{'205}
+  \DeclareMathSymbol\mathsection{\mathord}{textcomp}{'247}
+  \DeclareMathSymbol\mathparagraph{\mathord}{textcomp}{'266}
+\fi
+\DeclareTextSymbolDefault{\textless}{MY1}
+\DeclareTextSymbolDefault{\textgreater}{MY1}
+\DeclareTextAccentDefault{\t}{MY2}
+\DeclareTextSymbol{\textless}{MY1}{`\<}
+\DeclareTextSymbol{\textgreater}{MY1}{`\>}
+\DeclareTextAccent{\t}{MY2}{65}
+\DeclareTextSymbolDefault{\textasteriskcentered}{MY2}
+\DeclareTextSymbolDefault{\textbackslash}{MY2}
+\DeclareTextSymbolDefault{\textbar}{MY2}
+\DeclareTextSymbolDefault{\textbraceleft}{MY2}
+\DeclareTextSymbolDefault{\textbraceright}{MY2}
+\DeclareTextSymbolDefault{\textbullet}{MY2}
+\DeclareTextSymbolDefault{\textperiodcentered}{MY2}
+\DeclareTextAccentDefault{\textcircled}{MY2}
+\DeclareTextSymbol{\textasteriskcentered}{MY2}{3}
+\DeclareTextSymbol{\textbackslash}{MY2}{110}
+\DeclareTextSymbol{\textbar}{MY2}{106}
+\DeclareTextSymbol{\textbraceleft}{MY2}{102}
+\DeclareTextSymbol{\textbraceright}{MY2}{103}
+\DeclareTextSymbol{\textbullet}{MY2}{15}
+\DeclareTextSymbol{\textperiodcentered}{MY2}{1}
+\DeclareTextCommand{\textcircled}{MY2}[1]{{%
+   \ooalign{%
+      \hfil \raise .07ex\hbox {\upshape#1}\hfil \crcr
+      \char13}}}
+\ifx\symtextcomp\relax
+\else
+  \DeclareTextSymbolDefault{\textsection}{TS1}
+  \DeclareTextSymbolDefault{\textparagraph}{TS1}
+  \DeclareTextSymbol{\textsection}{TS1}{'247}
+  \DeclareTextSymbol{\textparagraph}{TS1}{'266}
+\fi
+\begingroup
+ \catcode`\_=13
+ \gdef_#1{\sb{\test@sb#1}}
+\endgroup
+\def\test@sb{%
+  \@ifnextchar p%
+    {\mkern\m@ne mu}%
+    {\ifx\@let@token j%
+       \mkern-\tw@ mu%
+     \else
+       \ifx\@let@token f%
+         \mkern-\tw@ mu%
+       \fi
+     \fi}}
+\mathcode`\_=\string"8000
+
+\endinput
+%%
+%% End of file `mathtime.sty'.

--- a/tex_style/subeqn.clo
+++ b/tex_style/subeqn.clo
@@ -1,0 +1,56 @@
+% subeqn.sty 
+% ----------------------------------------------------------------------
+%                     This LaTeX environment  is for
+% printing   subequations.   To   use   this   environment,  include  in  the
+% \documentstyle header  a command to  load in the  .sty file containing this
+% macro. For example:
+%     \documentstyle[subeqn]{article}
+% if you  have the  macro in  a file subeqn.sty. The environment seems pretty
+% well documented in the comments.
+%
+% Modified : June 8, 1989.  You can now reference either individual
+%            equations in the subequations environment, or all of
+%            them.  If you use a \label command immediately after the
+%            \begin{subequations} command, then a reference to that
+%            label will generate a reference to the equation number
+%            without the alphabetic extension.
+%
+% Modified : 16 - january - 1989 by Johannes Braams ( BRAAMS@HLSDNL5)
+%            Added \global\@ignoretrue in the definition of
+%            \endsubequations in order to prevent a spurious space
+%            at the beginning of the next text-line. Also added %'s
+%            at the end of each command-line for the same reasons.
+%
+%%%----------------------------------------------------------------
+%%% File: subeqn.sty
+%%% The subequations environment %%%
+%
+% Within the subequations environment, the only change is that
+% equations are labeled differently.  The number stays the same,
+% and lower case letters are appended.  For example, if after doing
+% three equations, numbered 1, 2, and 3, you start a subequations
+% environmment and do three more equations, they will be numbered
+% 4a, 4b, and 4c.  After you end the subequations environment, the
+% next equation will be numbered 5.
+%
+% Both text and equations can be put inside the subequations environment.
+%
+% If you make any improvements, I'd like to hear about them.
+%
+%
+\newtoks\@stequation
+
+\def\subequations{\refstepcounter{equation}%
+\edef\@savedequation{\the\c@equation}%
+\@stequation=\expandafter{\theequation}%   %only want \theequation
+\edef\@savedtheequation{\the\@stequation}% %expanded once
+\edef\oldtheequation{\theequation}%
+\setcounter{equation}{0}%
+\def\theequation{\oldtheequation\alph{equation}}}%
+
+\def\endsubequations{%
+\setcounter{equation}{\@savedequation}%
+\@stequation=\expandafter{\@savedtheequation}%
+\edef\theequation{\the\@stequation}\global\@ignoretrue}
+%%%----------------------------
+

--- a/tex_style/subeqn.sty
+++ b/tex_style/subeqn.sty
@@ -1,0 +1,64 @@
+%
+% This LaTeX environment is for printing subequations.   
+% To use this environment, include in the \documentstyle 
+% header a command to load in the .sty file containing this macro.
+%
+% Example:
+%
+%   \documentstyle[11pt,subeqn]{article}
+%
+%   \begin{subequations}
+%   \begin{eqnarray}
+%   & & [equation] \label{1.1a} \\
+%   & & [equation] \label{1.1b}
+%   \end{eqnarray}
+%   \label{1.1}
+%   \end{subequations}
+%
+%   You can then refer to either 1.1, 1.1a, or 1.1b.
+%
+% Modified : June 8, 1989.  You can now reference either individual
+%            equations in the subequations environment, or all of
+%            them.  If you use a \label command immediately after the
+%            \begin{subequations} command, then a reference to that
+%            label will generate a reference to the equation number
+%            without the alphabetic extension.
+%
+% Modified : 16 - january - 1989 by Johannes Braams ( BRAAMS@HLSDNL5)
+%            Added \global\@ignoretrue in the definition of
+%            \endsubequations in order to prevent a spurious space
+%            at the beginning of the next text-line. Also added %'s
+%            at the end of each command-line for the same reasons.
+%
+%%%----------------------------------------------------------------
+%%% File: subeqn.sty
+%%% The subequations environment %%%
+%
+% Within the subequations environment, the only change is that
+% equations are labeled differently.  The number stays the same,
+% and lower case letters are appended.  For example, if after doing
+% three equations, numbered 1, 2, and 3, you start a subequations
+% environmment and do three more equations, they will be numbered
+% 4a, 4b, and 4c.  After you end the subequations environment, the
+% next equation will be numbered 5.
+%
+% Both text and equations can be put inside the subequations 
+% environment.
+% If you make any improvements, I'd like to hear about them.
+%
+%
+\newtoks\@stequation
+
+\def\subequations{\refstepcounter{equation}%
+  \edef\@savedequation{\the\c@equation}%
+  \@stequation=\expandafter{\theequation}%   %only want \theequation
+  \edef\@savedtheequation{\the\@stequation}% %expanded once
+  \edef\oldtheequation{\theequation}%
+  \setcounter{equation}{0}%
+  \def\theequation{\oldtheequation\alph{equation}}}%
+
+\def\endsubequations{%
+  \setcounter{equation}{\@savedequation}%
+  \@stequation=\expandafter{\@savedtheequation}%
+  \edef\theequation{\the\@stequation}\global\@ignoretrue}
+%%%----------------------------


### PR DESCRIPTION
This incorporates the style files and sets up the nbconvert template to use them.

There are some issues with the example provided by SIAM (it does not compile), so I have not been able to fully set the book up like their example.  Specifically,

1. We're not using the fonts specified there and
2. Currently the whole book appears as front matter.  For the mainmatter chapters, there is a figure that has not been provided to us.  I'll update this once a complete working example is provided by SIAM.