### PR TITLE
make_html now copies html folder

### DIFF
--- a/make_html_on_master.py
+++ b/make_html_on_master.py
@@ -81,8 +81,10 @@ os.system('mkdir -p build_html')  # for intermediate processing
 os.system('cp -r exact_solvers build_html/')
 os.system('cp -r utils build_html/')
 os.system('cp -r figures build_html/')
+os.system('cp -r html build_html/')
 os.system('cp custom.css build_html/')
 os.system('cp html_animations/* build_html/')
+
 
 # Putting figures inside an img folder doesn't seem to be needed now:
 #os.system('mkdir -p build_html/img')  # for viewing images


### PR DESCRIPTION
Make html now copies the html folder into build_html. This allows the html version to run the interactive apps using the IFrame command.