### PR TITLE
Use matplotlib to properly render JSAnimations

### DIFF
--- a/Kitchen_sink_problem.ipynb
+++ b/Kitchen_sink_problem.ipynb
@@ -11,7 +11,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false,
     "tags": [
      "hide"
     ]
@@ -443,16 +442,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "claw = setup()\n",
     "claw.verbosity=0\n",
     "claw.run()\n",
     "\n",
-    "ianimate(claw)"
+    "anim = ianimate(claw)\n",
+    "HTML(anim.to_jshtml())"
    ]
   },
   {
@@ -506,16 +504,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "claw = setup_constant_initial_data()\n",
     "claw.verbosity=0\n",
     "claw.run()\n",
     "\n",
-    "ianimate(claw)"
+    "anim = ianimate(claw)\n",
+    "HTML(anim.to_jshtml())"
    ]
   },
   {
@@ -726,25 +723,38 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "claw = setup()\n",
     "claw.solver.bc_upper[0] = pyclaw.BC.extrap\n",
     "claw.verbosity = 0\n",
-    "claw.run()\n",
-    "\n",
-    "ianimate(claw)"
+    "claw.run()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "anim = ianimate(claw);\n",
+    "HTML(anim.to_jshtml())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/exact_solvers/acoustics_demos.py
+++ b/exact_solvers/acoustics_demos.py
@@ -5,6 +5,7 @@ import sys, os
 from clawpack import pyclaw
 from clawpack import riemann
 from matplotlib import animation
+from IPython.display import HTML
 import matplotlib.pyplot as plt
 import matplotlib.gridspec as gridspec
 import numpy as np
@@ -541,7 +542,8 @@ def bump_animation(numframes):
         line[1].set_data(x,velocity)
         return line,
 
-    return animation.FuncAnimation(fig, fplot, frames=len(frames), interval=30)
+    anim = animation.FuncAnimation(fig, fplot, frames=len(frames), interval=30)
+    return HTML(anim.to_jshtml())
 
 
 def bump_pyclaw(numframes):

--- a/exact_solvers/burgers_demos.py
+++ b/exact_solvers/burgers_demos.py
@@ -7,6 +7,7 @@ from clawpack import riemann
 import matplotlib
 import matplotlib.pyplot as plt
 from matplotlib import animation
+from IPython.display import HTML
 import numpy as np
 from utils import riemann_tools
 from . import burgers
@@ -143,7 +144,8 @@ def bump_animation(numframes):
         line.set_data(x,pressure)
         return line,
 
-    return animation.FuncAnimation(fig, fplot, frames=len(frames), interval=30)
+    anim = animation.FuncAnimation(fig, fplot, frames=len(frames), interval=30)
+    return HTML(anim.to_jshtml())
 
 def bump_pyclaw(numframes):
     """Returns pyclaw solution of bump initial condition."""
@@ -215,7 +217,8 @@ def triplestate_animation(ql, qm, qr, numframes):
         line[1].set_data(x,0*x+frame.t)
         return line
 
-    return animation.FuncAnimation(fig, fplot, frames=len(frames), interval=30, blit=False)
+    anim = animation.FuncAnimation(fig, fplot, frames=len(frames), interval=30, blit=False)
+    return HTML(anim.to_jshtml())
 
 def triplestate_pyclaw(ql, qm, qr, numframes):
     """Returns pyclaw solution of triple-state initial condition."""

--- a/utils/animation_tools.py
+++ b/utils/animation_tools.py
@@ -46,6 +46,7 @@ from __future__ import print_function
 
 from IPython.display import display
 from matplotlib import image, animation
+from IPython.display import HTML
 from matplotlib import pyplot as plt
 from ipywidgets import interact, interact_manual
 import ipywidgets
@@ -171,7 +172,7 @@ def JSAnimate_images(images, figsize=(10,6), dpi=None):
                                    blit=True)
 
     plt.close(fig)
-    return anim
+    return HTML(anim.to_jshtml())
 
 
 def make_html(anim, file_name='anim.html', title=None, raw_html='',


### PR DESCRIPTION
This deals with the failures we're seeing in #189.  I think this was caused by a recent change to matplotlib.  In any case, it seems necessary now to use `HTML(anim.to_jshtml())` to properly display JS animations in the notebook.  I fixed everything except animation_tools; I'm not completely sure what to do there because I don't know the intended behavior of all the individual functions.